### PR TITLE
Only log warnings about missing gnuplot unless explicitely requested

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -535,8 +535,8 @@ impl Default for Criterion {
             plotting = if criterion_plot::version().is_ok() {
                 Plotting::Enabled
             } else {
-                println!("Gnuplot not found, disabling plotting");
-
+                info!("Gnuplot not found while creating default \
+                       settings, disabling!");
                 Plotting::NotAvailable
             };
             reports.push(Box::new(Html::new()));
@@ -688,7 +688,8 @@ impl Criterion {
     /// Enables plotting
     pub fn with_plots(mut self) -> Criterion {
         match self.plotting {
-            Plotting::NotAvailable => {}
+            Plotting::NotAvailable => panic!("Plotting explicitely requested \
+              but gnuplot was not found!"),
             _ => self.plotting = Plotting::Enabled,
         }
 


### PR DESCRIPTION
In which case we panic instead of continuing silently.

So this was bugging me a bit, always getting the messages about missing gnuplot. I suggest only logging a message in the `default()` constructor.

During fixing that I saw that `with_plots` silently continues if gnuplot isn't found. In my book that's not a good thing, so I changed it to panic with a message (other setting functions also panic if you use a wrong parameter, so that seemed the way forward). Note that this does what I think it should if one uses it after `Criterion::default()`, but if someone put up a custom `Criterion` struct (it's `pub` after all), there might be some disconnect. I suggest redoing the `criterion_plot::version` within `with_plots`, but I'll wait on your judgement on that.

(e) I'm not sure what's borking the formatting here, looks ok locally, and I did not use any tabs.