### PR TITLE
 Replace `unsafe` thread-scoped and num_cpus with rayon 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Criterion.rs now uses `rayon` internally instead of manual `unsafe` code built on top thread-scoped.
+
 ## [0.2.6] - 2018-12-27
 ### Added
 - Added `--list` command line option, which lists the benchmarks but does not run them, to match

--- a/stats/Cargo.toml
+++ b/stats/Cargo.toml
@@ -13,9 +13,8 @@ license = "MIT/Apache-2.0"
 [dependencies]
 cast = "0.2"
 num-traits = "0.2"
-num_cpus = "1"
 rand = "~0.4"   # 0.4 is required to maintain compatibility with Rust 1.20
-thread-scoped = "1.0.2"
+rayon = "1.0.3"
 
 [dev-dependencies]
 approx = "0.3"

--- a/stats/src/bivariate/mod.rs
+++ b/stats/src/bivariate/mod.rs
@@ -5,11 +5,8 @@ mod resamples;
 
 pub mod regression;
 
-use std::cmp;
-
 use float::Float;
-use num_cpus;
-use thread_scoped as thread;
+use rayon::prelude::*;
 
 use bivariate::resamples::Resamples;
 use tuple::{Tuple, TupledDistributionsBuilder};
@@ -82,50 +79,31 @@ where
     where
         S: Fn(Data<X, Y>) -> T,
         S: Sync,
-        T: Tuple,
+        T: Tuple + Send,
         T::Distributions: Send,
         T::Builder: Send,
     {
-        let ncpus = num_cpus::get();
-
-        unsafe {
-            // TODO need some sensible threshold to trigger the multi-threaded path
-            if ncpus > 1 && nresamples > self.0.len() {
-                let granularity = nresamples / ncpus + 1;
-                let statistic = &statistic;
-
-                let chunks = (0..ncpus)
-                    .map(|i| {
-                        let mut sub_distributions: T::Builder =
-                            TupledDistributionsBuilder::new(granularity);
-                        let mut resamples = Resamples::new(*self);
-                        let offset = i * granularity;
-
-                        thread::scoped(move || {
-                            for _ in offset..cmp::min(offset + granularity, nresamples) {
-                                sub_distributions.push(statistic(resamples.next()))
-                            }
-                            sub_distributions
-                        })
-                    })
-                    .collect::<Vec<_>>();
-
-                let mut builder: T::Builder = TupledDistributionsBuilder::new(nresamples);
-                for chunk in chunks {
-                    builder.extend(&mut (chunk.join()));
-                }
-                builder.complete()
-            } else {
-                let mut distributions: T::Builder = TupledDistributionsBuilder::new(nresamples);
-                let mut resamples = Resamples::new(*self);
-
-                for _ in 0..nresamples {
-                    distributions.push(statistic(resamples.next()));
-                }
-
-                distributions.complete()
-            }
-        }
+        (0..nresamples)
+            .into_par_iter()
+            .map_init(
+                || Resamples::new(*self),
+                |resamples, _| statistic(resamples.next()),
+            )
+            .fold(
+                || T::Builder::new(0),
+                |mut sub_distributions, sample| {
+                    sub_distributions.push(sample);
+                    sub_distributions
+                },
+            )
+            .reduce(
+                || T::Builder::new(0),
+                |mut a, mut b| {
+                    a.extend(&mut b);
+                    a
+                },
+            )
+            .complete()
     }
 
     /// Returns a view into the `X` data

--- a/stats/src/lib.rs
+++ b/stats/src/lib.rs
@@ -17,10 +17,9 @@
 )]
 
 extern crate cast;
-extern crate num_cpus;
 extern crate num_traits;
 extern crate rand;
-extern crate thread_scoped;
+extern crate rayon;
 
 #[cfg(test)]
 #[macro_use]

--- a/stats/src/univariate/sample.rs
+++ b/stats/src/univariate/sample.rs
@@ -131,7 +131,7 @@ where
         }
 
         let mut v = self.to_vec().into_boxed_slice();
-        v.sort_by(cmp);
+        v.par_sort_unstable_by(cmp);
 
         // NB :-1: to intra-crate privacy rules
         unsafe { mem::transmute(v) }


### PR DESCRIPTION
This does not seem to result in any regressions in performance, and
possibly some small (~5%) speed-ups. This is technically a breaking
change, as it required adding some trait bounds to some functions, but
anyone that is actually broken risks having memory
unsafety (non-`Send` types being sent across threads).

Work towards #195.

Also, since rayon makes it so easy:


Use rayon's par_sort_unstable_by for dramatic `percentile` speedup 

For the benchmarks that call `percentile` on large arrays (e.g. 1
million in the ones below), this gives a very large speed-up: >80%
less time taken/5x faster.

```
stat_f64_iqr            time:   [16.732 ms 17.470 ms 18.287 ms]
                        change: [-81.695% -81.052% -80.361%] (p = 0.00 < 0.05)
stat_f64_median         time:   [13.657 ms 13.809 ms 13.953 ms]
                        change: [-85.984% -85.696% -85.421%] (p = 0.00 < 0.05)
```

(It means that it's a `cargo bench` run could finish on my machine. I wasn't patient enough to leave my computer unused for benchmarks like `median_abs_dev` to finish before: the prediction was >10 minutes for just that one.)