### PR TITLE
Enable proper text coloring on Windows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -972,7 +972,7 @@ scripts alongside the generated plots.
                 enable_text_coloring = false;
                 enable_text_overwrite = false;
             }
-            _ => enable_text_coloring = cfg!(unix) && stdout_isatty,
+            _ => enable_text_coloring = stdout_isatty,
         }
 
         if matches.is_present("noplot") || matches.is_present("test") {


### PR DESCRIPTION
That PR addresses #267. According to rust-lang/cargo#4722 the misbehaving of color output with `rustc` and `cargo` has been fixed. Also `atty` is able to properly determine whether we use TTY on Windows or not. That small fix correctly enables color ouput while using Windows `cmd` and `powershell` utilities and also does not break down compatibility with Unix terminal programs.

I'd like to ask @alekseysidorov to validate whether that fix properly works on his machine. My test configuration was the following:
* Windows 10 (`build 1809 - 10.0.17763`)
* `rust 1.32.0`
* `rust 1.33.0`