### PR TITLE
Issue 272

### DIFF
--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -3,7 +3,6 @@ use program::CommandFactory;
 use report::{BenchmarkId, ReportContext};
 use routine::{Function, Routine};
 use std::cell::RefCell;
-use std::collections::HashSet;
 use std::fmt::Debug;
 use std::marker::Sized;
 use std::process::Command;
@@ -389,7 +388,6 @@ impl BenchmarkDefinition for Benchmark {
 
         let mut all_ids = vec![];
         let mut any_matched = false;
-        let mut all_titles = HashSet::new();
 
         for routine in self.routines {
             let function_id = if num_routines == 1 && group_id == routine.id {
@@ -407,8 +405,8 @@ impl BenchmarkDefinition for Benchmark {
 
             id.ensure_directory_name_unique(&c.all_directories);
             c.all_directories.insert(id.as_directory_name().to_owned());
-            id.ensure_title_unique(&all_titles);
-            all_titles.insert(id.as_title().to_owned());
+            id.ensure_title_unique(&c.all_titles);
+            c.all_titles.insert(id.as_title().to_owned());
 
             if c.filter_matches(id.id()) {
                 any_matched = true;
@@ -654,7 +652,6 @@ where
 
         let mut all_ids = vec![];
         let mut any_matched = false;
-        let mut all_titles = HashSet::new();
 
         for routine in self.routines {
             for value in &self.values {
@@ -680,8 +677,8 @@ where
 
                 id.ensure_directory_name_unique(&c.all_directories);
                 c.all_directories.insert(id.as_directory_name().to_owned());
-                id.ensure_title_unique(&all_titles);
-                all_titles.insert(id.as_title().to_owned());
+                id.ensure_title_unique(&c.all_titles);
+                c.all_titles.insert(id.as_title().to_owned());
 
                 if c.filter_matches(id.id()) {
                     any_matched = true;

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -90,7 +90,7 @@ pub struct Benchmark {
 /// used outside of Criterion.rs.
 pub trait BenchmarkDefinition: Sized {
     #[doc(hidden)]
-    fn run(self, group_id: &str, c: &Criterion);
+    fn run(self, group_id: &str, c: &mut Criterion);
 }
 
 macro_rules! benchmark_config {
@@ -376,7 +376,7 @@ impl Benchmark {
 }
 
 impl BenchmarkDefinition for Benchmark {
-    fn run(self, group_id: &str, c: &Criterion) {
+    fn run(self, group_id: &str, c: &mut Criterion) {
         let report_context = ReportContext {
             output_directory: c.output_directory.clone(),
             plotting: c.plotting,
@@ -389,7 +389,6 @@ impl BenchmarkDefinition for Benchmark {
 
         let mut all_ids = vec![];
         let mut any_matched = false;
-        let mut all_directories = HashSet::new();
         let mut all_titles = HashSet::new();
 
         for routine in self.routines {
@@ -406,8 +405,8 @@ impl BenchmarkDefinition for Benchmark {
                 self.throughput.clone(),
             );
 
-            id.ensure_directory_name_unique(&all_directories);
-            all_directories.insert(id.as_directory_name().to_owned());
+            id.ensure_directory_name_unique(&c.all_directories);
+            c.all_directories.insert(id.as_directory_name().to_owned());
             id.ensure_title_unique(&all_titles);
             all_titles.insert(id.as_title().to_owned());
 
@@ -641,7 +640,7 @@ impl<T> BenchmarkDefinition for ParameterizedBenchmark<T>
 where
     T: Debug + 'static,
 {
-    fn run(self, group_id: &str, c: &Criterion) {
+    fn run(self, group_id: &str, c: &mut Criterion) {
         let report_context = ReportContext {
             output_directory: c.output_directory.clone(),
             plotting: c.plotting,
@@ -655,7 +654,6 @@ where
 
         let mut all_ids = vec![];
         let mut any_matched = false;
-        let mut all_directories = HashSet::new();
         let mut all_titles = HashSet::new();
 
         for routine in self.routines {
@@ -680,8 +678,8 @@ where
                     throughput.clone(),
                 );
 
-                id.ensure_directory_name_unique(&all_directories);
-                all_directories.insert(id.as_directory_name().to_owned());
+                id.ensure_directory_name_unique(&c.all_directories);
+                c.all_directories.insert(id.as_directory_name().to_owned());
                 id.ensure_title_unique(&all_titles);
                 all_titles.insert(id.as_title().to_owned());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -622,6 +622,7 @@ pub struct Criterion {
     test_mode: bool,
     list_mode: bool,
     all_directories: HashSet<String>,
+    all_titles: HashSet<String>,
 }
 
 impl Default for Criterion {
@@ -670,6 +671,7 @@ impl Default for Criterion {
             list_mode: false,
             output_directory,
             all_directories: HashSet::new(),
+            all_titles: HashSet::new(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,7 @@ mod plot;
 mod html;
 
 use std::cell::RefCell;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::default::Default;
 use std::fmt;
 use std::iter::IntoIterator;
@@ -621,6 +621,7 @@ pub struct Criterion {
     profile_time: Option<Duration>,
     test_mode: bool,
     list_mode: bool,
+    all_directories: HashSet<String>,
 }
 
 impl Default for Criterion {
@@ -668,6 +669,7 @@ impl Default for Criterion {
             test_mode: false,
             list_mode: false,
             output_directory,
+            all_directories: HashSet::new(),
         }
     }
 }

--- a/src/report.rs
+++ b/src/report.rs
@@ -777,4 +777,15 @@ mod test {
         assert_eq!("group/function/value_3", new_id.as_directory_name());
         directories.insert(new_id.as_directory_name().to_owned());
     }
+    #[test]
+    fn test_benchmark_id_make_long_directory_name_unique() {
+        let long_name = (0..MAX_DIRECTORY_NAME_LEN).map(|_| 'a').collect::<String>();
+        let existing_id = BenchmarkId::new(long_name, None, None, None);
+        let mut directories = HashSet::new();
+        directories.insert(existing_id.as_directory_name().to_owned());
+
+        let mut new_id = existing_id.clone();
+        new_id.ensure_directory_name_unique(&directories);
+        assert_ne!(existing_id.as_directory_name(), new_id.as_directory_name());
+    }
 }


### PR DESCRIPTION
Most of the code to avoid duplicate directories was already in place.
The only problem was that the cache of directories that is checked for duplicates
didn't outlive a single call to `Benchmark::run.`
Fix it by making this cache a member of `Criterion` so it does live long enough to
be useful in the situation that my usecase exposed.