### PR TITLE
Fix trailing spaces in filenames on Windows

### DIFF
--- a/src/report.rs
+++ b/src/report.rs
@@ -83,13 +83,27 @@ pub fn make_filename_safe(string: &str) -> String {
         "_",
     );
 
-    // On Windows, file names are not case-sensitive, so lowercase everything.
-    if cfg!(target_os = "windows") {
-        string = string.to_lowercase();
-    }
-
     // Truncate to last character boundary before max length...
     truncate_to_character_boundary(&mut string, MAX_DIRECTORY_NAME_LEN);
+
+    if cfg!(target_os = "windows") {
+        // TODO: remove `allow(...)` when we don't support Rust < 1.30.
+        // (this is needed for `.trim_right` which is deprecated in favour of `.trim_end`)
+        #[allow(deprecated)]
+        {
+            string = string
+                // On Windows, spaces in the end of the filename are ignored and will be trimmed.
+                //
+                // Without trimming ourselves, creating a directory `dir ` will silently create
+                // `dir` instead, but then operations on files like `dir /file` will fail.
+                //
+                // Also note that it's important to do this *after* trimming to MAX_DIRECTORY_NAME_LEN,
+                // otherwise it can trim again to a name with a trailing space.
+                .trim_right()
+                // On Windows, file names are not case-sensitive, so lowercase everything.
+                .to_lowercase();
+        }
+    }
 
     string
 }


### PR DESCRIPTION
See the comment - basically the problem, is that Windows doesn't allow trailing spaces in filename, and instead silently trims them.

This works more or less well for file access, since the filename is trimmed in the same way both on creating and on access, but when used with directories, trying to create something like `dir /file` will simply fail with no apparent reason.

This was a problem before, but it was additionally revealed by the introduction of MAX_DIRECTORY_NAME_LEN since now name can be trimmed to a one with a trailing space much more frequently.