### PR TITLE
Fix overhead of iter_batched{_ref}

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -475,14 +475,14 @@ impl Bencher {
             while iteration_counter < self.iters {
                 let batch_size = ::std::cmp::min(batch_size, self.iters - iteration_counter);
 
-                let inputs = (0..batch_size).map(|_| setup()).collect::<Vec<_>>();
+                let inputs = black_box((0..batch_size).map(|_| setup()).collect::<Vec<_>>());
                 let mut outputs = Vec::with_capacity(batch_size as usize);
 
                 let start = Instant::now();
-                outputs.extend(inputs.into_iter().map(|i| black_box(routine(i))));
+                outputs.extend(inputs.into_iter().map(&mut routine));
                 self.elapsed += start.elapsed();
 
-                drop(outputs);
+                black_box(outputs);
 
                 iteration_counter += batch_size;
             }
@@ -561,15 +561,14 @@ impl Bencher {
             while iteration_counter < self.iters {
                 let batch_size = ::std::cmp::min(batch_size, self.iters - iteration_counter);
 
-                let mut inputs = (0..batch_size).map(|_| setup()).collect::<Vec<_>>();
+                let mut inputs = black_box((0..batch_size).map(|_| setup()).collect::<Vec<_>>());
                 let mut outputs = Vec::with_capacity(batch_size as usize);
 
                 let start = Instant::now();
-                outputs.extend(inputs.iter_mut().map(|i| black_box(routine(i))));
+                outputs.extend(inputs.iter_mut().map(&mut routine));
                 self.elapsed += start.elapsed();
 
-                drop(outputs);
-                drop(inputs);
+                black_box(outputs);
 
                 iteration_counter += batch_size;
             }


### PR DESCRIPTION
Looks like newly added `iter_batched` and `iter_batched_ref` methods re-introduced same problem as I've fixed in the past for `iter_with_*` methods in #214.

This essentially applies same fixes to the new methods.

Original quote from #214:
> Remove `black_box` from the hot path where possible (it's necessary to prevent optimisations, but doesn't have to be part of the measurement, especially the expensive `black_box` fallback used on stable Rust).

Some numbers from `cargo bench -- overhead/iter_batched`:

| name | diff |
|-|-|
| `iter_batched_small_input` | -22% |
| `iter_batched_large_input` | -54% |
| `iter_batched_per_iteration` | no change |
| `iter_batched_ref_small_input` | -26% |
| `iter_batched_ref_large_input` | -87% |
| `iter_batched_ref_large_input` | no change |