### PR TITLE
Don't panic on non-existent test combinations

### DIFF
--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -244,7 +244,7 @@ impl<'a> BenchmarkGroup<'a> {
         for value in values.iter() {
             let row = function_ids
                 .iter()
-                .map(|f| individual_links.remove(&(*f, *value)).unwrap())
+                .filter_map(|f| individual_links.remove(&(*f, *value)))
                 .collect::<Vec<_>>();
             value_groups.push(BenchmarkValueGroup {
                 value: value.map(|s| ReportLink::value(output_directory, group_id, s)),


### PR DESCRIPTION
If you run a single test there could be a test result entry like:

    BenchmarkId { group_id: "mytest", function_id: None, value_str: None, throughput: None }

If you now change that test and make it a parameterized test
with the same name, there could be additional entries like:

    BenchmarkId { group_id: "mytest", function_id: "test_fun", value_str: "3", throughput: None },
    BenchmarkId { group_id: "mytest", function_id: "test_fun", value_str: "5", throughput: None }

In order to build a report every combination of the `function_id`
and `value_str` is used
(https://github.com/bheisler/criterion.rs/blob/cc4d5e841b4855db08d2501eee34f560d580880a/src/html/mod.rs#L247).

That's not correct, as the combination `test_fun` and `None` doesn't exist. The fix is to
ignore the cases when such a combination doesn't exist.

Fixes #269.