### PR TITLE
WIP: Linux perf counters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ rayon = "1.0.3"
 # These are needed for the minimal-versions build
 rayon-core = ">=1.4.1"
 libc = ">=0.1.5"
+perfcnt = "0.4"
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/src/program.rs
+++ b/src/program.rs
@@ -5,7 +5,7 @@ use std::process::{Child, ChildStderr, ChildStdin, ChildStdout, Command, Stdio};
 use std::time::{Duration, Instant};
 
 use routine::Routine;
-use DurationExt;
+use {DurationExt, PerfCnt};
 
 // A two-way channel to the standard streams of a child process
 pub struct Program {
@@ -73,7 +73,7 @@ impl Program {
         }
     }
 
-    fn bench(&mut self, iters: &[u64]) -> Vec<f64> {
+    fn bench(&mut self, iters: &[u64]) -> Vec<(f64, PerfCnt)> {
         let mut n = 0;
         for iters in iters {
             self.send(iters);
@@ -86,7 +86,7 @@ impl Program {
                 let msg = msg.trim();
 
                 let elapsed: u64 = msg.parse().expect("Couldn't parse program output");
-                elapsed as f64
+                (elapsed as f64, PerfCnt::default())
             })
             .collect()
     }
@@ -115,7 +115,12 @@ impl Routine<()> for Command {
         Some(Program::spawn(self))
     }
 
-    fn bench(&mut self, program: &mut Option<Program>, iters: &[u64], _: &()) -> Vec<f64> {
+    fn bench(
+        &mut self,
+        program: &mut Option<Program>,
+        iters: &[u64],
+        _: &(),
+    ) -> Vec<(f64, PerfCnt)> {
         let program = program.as_mut().unwrap();
         program.bench(iters)
     }
@@ -159,7 +164,12 @@ where
         Some(Program::spawn(&mut command))
     }
 
-    fn bench(&mut self, program: &mut Option<Program>, iters: &[u64], _: &T) -> Vec<f64> {
+    fn bench(
+        &mut self,
+        program: &mut Option<Program>,
+        iters: &[u64],
+        _: &T,
+    ) -> Vec<(f64, PerfCnt)> {
         let program = program.as_mut().unwrap();
         program.bench(iters)
     }

--- a/src/report.rs
+++ b/src/report.rs
@@ -113,7 +113,6 @@ impl BenchmarkId {
         if title != full_id {
             title.push_str("...");
         }
-
         let directory_name = match (&function_id, &value_str) {
             (&Some(ref func), &Some(ref val)) => format!(
                 "{}/{}/{}",


### PR DESCRIPTION
Heya,
I am looking at including linux perf counters (such as cpu cycle, cach misses etc.) to criterion. It'd allow not only drive benchmarks on pure time but also other vectors that affect performance.

At this point this is nothing more then a proof of concept how hard that is in rust turns out it's a bit of legwork but not too hard.

Before going on I want to make sure there is interest in merging something like this. Since it depends on nightly code it'd need to be fenced of behind a feature flag but it I see it being possibly quite valuable non the less.

If ther is interest I'd love to get some input how to best put it in criterion itself so it doesn't get in the way of design or future goals.

Chears!

my TODO (Before WIP end so I don't forget things):
- [ ] Fence of unstable bits
- [ ] Remove rust-toolchain
