### PR TITLE
Update rand dependencies to those in 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,9 @@ walkdir = "2.2.7"
 tinytemplate = { version = "1.0.1", optional = true }
 cast = "0.2"
 num-traits = "0.2"
-rand_os = "0.1"
-rand_xoshiro = "0.1"
-rand_core = { version = "0.3", default-features = false }
+rand_os = "0.2"
+rand_xoshiro = "0.3"
+rand_core = { version = "0.5", default-features = false }
 rayon = "1.0.3"
 # These are needed for the minimal-versions build
 rayon-core = ">=1.4.1"
@@ -38,7 +38,7 @@ libc = ">=0.1.5"
 tempdir = "0.3.7"
 approx = "0.3"
 quickcheck = { version = "0.8, <0.8.3", default-features = false }
-rand = "0.6"
+rand = "0.7"
 
 [badges]
 travis-ci = { repository = "bheisler/criterion.rs" }

--- a/src/stats/rand_util.rs
+++ b/src/stats/rand_util.rs
@@ -7,7 +7,7 @@ use std::cell::RefCell;
 pub type Rng = Xoshiro256StarStar;
 
 thread_local! {
-    static SEED_RAND: RefCell<OsRng> = RefCell::new(OsRng::new().unwrap());
+    static SEED_RAND: RefCell<OsRng> = RefCell::new(OsRng);
 }
 
 pub fn new_rng() -> Rng {

--- a/src/stats/test.rs
+++ b/src/stats/test.rs
@@ -1,5 +1,5 @@
 use rand::distributions::{Distribution, Standard};
-use rand::{FromEntropy, Rng};
+use rand::prelude::*;
 use rand_xoshiro::Xoshiro256StarStar;
 
 pub fn vec<T>(size: usize, start: usize) -> Option<Vec<T>>


### PR DESCRIPTION
I'm not sure if this still satisfies the minimum supported Rust version guarantees of criterion, but figured I'd put a PR up regardless that can be merged when appropriate :)