### PR TITLE
Remove byteorder-dependency

### DIFF
--- a/plot/Cargo.toml
+++ b/plot/Cargo.toml
@@ -11,7 +11,6 @@ categories = ["visualization"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-byteorder = "1"
 cast = "0.2"
 itertools = "0.8"
 

--- a/plot/src/data.rs
+++ b/plot/src/data.rs
@@ -2,7 +2,6 @@
 
 use std::mem;
 
-use byteorder::{LittleEndian, WriteBytesExt};
 use cast::From as _0;
 
 use traits::Data;
@@ -81,6 +80,10 @@ pub trait Row {
     fn ncols() -> usize;
 }
 
+fn write_f64(w: &mut impl std::io::Write, f: f64) -> std::io::Result<()> {
+    w.write_all(&f.to_bits().to_le_bytes())
+}
+
 impl<A, B> Row for (A, B)
 where
     A: Data,
@@ -91,8 +94,8 @@ where
     fn append_to(self, buffer: &mut Vec<u8>, scale: (f64, f64)) {
         let (a, b) = self;
 
-        buffer.write_f64::<LittleEndian>(a.f64() * scale.0).unwrap();
-        buffer.write_f64::<LittleEndian>(b.f64() * scale.1).unwrap();
+        write_f64(buffer, a.f64() * scale.0).unwrap();
+        write_f64(buffer, b.f64() * scale.1).unwrap();
     }
 
     fn ncols() -> usize {
@@ -111,9 +114,9 @@ where
     fn append_to(self, buffer: &mut Vec<u8>, scale: (f64, f64, f64)) {
         let (a, b, c) = self;
 
-        buffer.write_f64::<LittleEndian>(a.f64() * scale.0).unwrap();
-        buffer.write_f64::<LittleEndian>(b.f64() * scale.1).unwrap();
-        buffer.write_f64::<LittleEndian>(c.f64() * scale.2).unwrap();
+        write_f64(buffer, a.f64() * scale.0).unwrap();
+        write_f64(buffer, b.f64() * scale.1).unwrap();
+        write_f64(buffer, c.f64() * scale.2).unwrap();
     }
 
     fn ncols() -> usize {
@@ -133,10 +136,10 @@ where
     fn append_to(self, buffer: &mut Vec<u8>, scale: (f64, f64, f64, f64)) {
         let (a, b, c, d) = self;
 
-        buffer.write_f64::<LittleEndian>(a.f64() * scale.0).unwrap();
-        buffer.write_f64::<LittleEndian>(b.f64() * scale.1).unwrap();
-        buffer.write_f64::<LittleEndian>(c.f64() * scale.2).unwrap();
-        buffer.write_f64::<LittleEndian>(d.f64() * scale.3).unwrap();
+        write_f64(buffer, a.f64() * scale.0).unwrap();
+        write_f64(buffer, b.f64() * scale.1).unwrap();
+        write_f64(buffer, c.f64() * scale.2).unwrap();
+        write_f64(buffer, d.f64() * scale.3).unwrap();
     }
 
     fn ncols() -> usize {
@@ -158,11 +161,11 @@ where
     fn append_to(self, buffer: &mut Vec<u8>, scale: (f64, f64, f64, f64, f64)) {
         let (a, b, c, d, e) = self;
 
-        buffer.write_f64::<LittleEndian>(a.f64() * scale.0).unwrap();
-        buffer.write_f64::<LittleEndian>(b.f64() * scale.1).unwrap();
-        buffer.write_f64::<LittleEndian>(c.f64() * scale.2).unwrap();
-        buffer.write_f64::<LittleEndian>(d.f64() * scale.3).unwrap();
-        buffer.write_f64::<LittleEndian>(e.f64() * scale.4).unwrap();
+        write_f64(buffer, a.f64() * scale.0).unwrap();
+        write_f64(buffer, b.f64() * scale.1).unwrap();
+        write_f64(buffer, c.f64() * scale.2).unwrap();
+        write_f64(buffer, d.f64() * scale.3).unwrap();
+        write_f64(buffer, e.f64() * scale.4).unwrap();
     }
 
     fn ncols() -> usize {

--- a/plot/src/lib.rs
+++ b/plot/src/lib.rs
@@ -400,7 +400,6 @@
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::doc_markdown))]
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::many_single_char_names))]
 
-extern crate byteorder;
 extern crate cast;
 #[macro_use]
 extern crate itertools;


### PR DESCRIPTION
This removes the `byteorder`-dependency, which is not needed since 1.32. This raises the minimal Rust version to 1.32, which is in line with "within last three stable versions". Dropping a dependency is worth the change IMHO.