### PR TITLE
Add more command line arguments

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -941,6 +941,34 @@ impl Criterion {
                 .long("profile-time")
                 .takes_value(true)
                 .help("Iterate each benchmark for approximately the given number of seconds, doing no analysis and without storing the results. Useful for running the benchmarks in a profiler."))
+            .arg(Arg::with_name("sample-size")
+                .long("sample-size")
+                .takes_value(true)
+                .help("Changes the default size of the sample for benchmarks run with this runner."))
+            .arg(Arg::with_name("warm-up-time")
+                .long("warm-up-time")
+                .takes_value(true)
+                .help("Changes the default warm up time for benchmarks run with this runner."))
+            .arg(Arg::with_name("measurement-time")
+                .long("measurement-time")
+                .takes_value(true)
+                .help("Changes the default measurement time for benchmarks run with this runner."))
+            .arg(Arg::with_name("nresamples")
+                .long("nresamples")
+                .takes_value(true)
+                .help("Changes the default number of resamples for benchmarks run with this runner."))
+            .arg(Arg::with_name("noise-threshold")
+                .long("noise-threshold")
+                .takes_value(true)
+                .help("Changes the default noise threshold for benchmarks run with this runner."))
+            .arg(Arg::with_name("confidence-level")
+                .long("confidence-level")
+                .takes_value(true)
+                .help("Changes the default confidence level for benchmarks run with this runner"))
+            .arg(Arg::with_name("significance-level")
+                .long("significance-level")
+                .takes_value(true)
+                .help("Changes the default significance level for benchmarks run with this runner"))
             .arg(Arg::with_name("test")
                 .long("test")
                 .help("Run the benchmarks once, to verify that they execute successfully, but do not measure or report the results."))
@@ -1021,6 +1049,86 @@ scripts alongside the generated plots.
             }
 
             self.profile_time = Some(Duration::from_secs(num_seconds));
+        }
+        if matches.is_present("sample-size") {
+            let num_size = value_t!(matches.value_of("sample-size"), usize).unwrap_or_else(|e| {
+                println!("{}", e);
+                std::process::exit(1)
+            });
+
+            assert!(num_size >= 2);
+            if num_size < 10 {
+                println!("Warning: Sample sizes < 10 will be disallowed in Criterion.rs 0.3.0.");
+            }
+
+            self.config.sample_size = num_size;
+        }
+        if matches.is_present("warm-up-time") {
+            let num_seconds = value_t!(matches.value_of("warm-up-time"), u64).unwrap_or_else(|e| {
+                println!("{}", e);
+                std::process::exit(1)
+            });
+
+            let dur = std::time::Duration::new(num_seconds, 0);
+            assert!(dur.to_nanos() > 0);
+
+            self.config.warm_up_time = dur;
+        }
+        if matches.is_present("measurement-time") {
+            let num_seconds =
+                value_t!(matches.value_of("measurement-time"), u64).unwrap_or_else(|e| {
+                    println!("{}", e);
+                    std::process::exit(1)
+                });
+
+            let dur = std::time::Duration::new(num_seconds, 0);
+            assert!(dur.to_nanos() > 0);
+
+            self.config.measurement_time = dur;
+        }
+        if matches.is_present("nresamples") {
+            let num_resamples =
+                value_t!(matches.value_of("nresamples"), usize).unwrap_or_else(|e| {
+                    println!("{}", e);
+                    std::process::exit(1)
+                });
+
+            assert!(num_resamples > 0);
+
+            self.config.nresamples = num_resamples;
+        }
+        if matches.is_present("noise-threshold") {
+            let num_noise_threshold = value_t!(matches.value_of("noise-threshold"), f64)
+                .unwrap_or_else(|e| {
+                    println!("{}", e);
+                    std::process::exit(1)
+                });
+
+            assert!(num_noise_threshold > 0.0);
+
+            self.config.noise_threshold = num_noise_threshold;
+        }
+        if matches.is_present("confidence-level") {
+            let num_confidence_level = value_t!(matches.value_of("confidence-level"), f64)
+                .unwrap_or_else(|e| {
+                    println!("{}", e);
+                    std::process::exit(1)
+                });
+
+            assert!(num_confidence_level > 0.0 && num_confidence_level < 1.0);
+
+            self.config.confidence_level = num_confidence_level;
+        }
+        if matches.is_present("significance-level") {
+            let num_significance_level = value_t!(matches.value_of("significance-level"), f64)
+                .unwrap_or_else(|e| {
+                    println!("{}", e);
+                    std::process::exit(1)
+                });
+
+            assert!(num_significance_level > 0.0 && num_significance_level < 1.0);
+
+            self.config.significance_level = num_significance_level;
         }
         self.test_mode = matches.is_present("test");
         if matches.is_present("list") {

--- a/src/report.rs
+++ b/src/report.rs
@@ -765,8 +765,7 @@ mod test {
 
     #[test]
     fn test_make_filename_safe_respects_character_boundaries() {
-        let input =
-            "✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓";
+        let input = "✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓";
         let safe = make_filename_safe(input);
         assert!(safe.len() < MAX_DIRECTORY_NAME_LEN);
     }


### PR DESCRIPTION
This add more command line arguments to `configure_from_args` method for #312 

- sample-size
- warm-up-time
- measurement-time
- nresamples
- noise-threshold
- confidence-level
- significance-level

These command line arguments are added to set default value for corresponding arguments of `Criterion`