### PR TITLE
[WIP] Adding a througput chart to the benchmark summary.

### DIFF
--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -808,11 +808,8 @@ impl Html {
             .collect();
         let mut line_tput_path = None;
 
-        if value_types.iter().all(|x| x == &value_types[0])
-            && throughput_types[0].is_some()
-            && throughput_types.iter().all(|x| x == &throughput_types[0])
-        {
-            if let Some(value_type) = value_types[0] {
+        let all_throughputs_match = value_types.iter().all(|x| x == &value_types[0]) && throughput_types[0].is_some();
+        if all_throughputs_match {
                 let values: Vec<_> = data.iter().map(|&&(ref id, _)| id.as_number()).collect();
                 if values.iter().any(|x| x != &values[0]) {
                     let path = format!(
@@ -826,13 +823,11 @@ impl Html {
                         id.as_title(),
                         data,
                         &path,
-                        value_type,
                         report_context.plot_config.summary_scale,
                     ));
 
                     line_tput_path = Some(path);
                 }
-            }
         }
 
         let path_prefix = if full_summary { "../.." } else { "../../.." };

--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -810,24 +810,20 @@ impl Html {
 
         let all_throughputs_match = value_types.iter().all(|x| x == &value_types[0]) && throughput_types[0].is_some();
         if all_throughputs_match {
-                let values: Vec<_> = data.iter().map(|&&(ref id, _)| id.as_number()).collect();
-                if values.iter().any(|x| x != &values[0]) {
-                    let path = format!(
-                        "{}/{}/report/lines_tput.svg",
-                        report_context.output_directory,
-                        id.as_directory_name()
-                    );
+            let path = format!(
+                "{}/{}/report/lines_tput.svg",
+                report_context.output_directory,
+                id.as_directory_name()
+            );
 
-                    gnuplots.push(plot::line_comparison_throughput(
-                        formatter,
-                        id.as_title(),
-                        data,
-                        &path,
-                        report_context.plot_config.summary_scale,
-                    ));
-
-                    line_tput_path = Some(path);
-                }
+            gnuplots.push(plot::comparison_throughput(
+                formatter,
+                id.as_title(),
+                data,
+                &path,
+                report_context.plot_config.summary_scale,
+            ));
+            line_tput_path = Some(path);
         }
 
         let path_prefix = if full_summary { "../.." } else { "../../.." };

--- a/src/html/summary_report.html.tt
+++ b/src/html/summary_report.html.tt
@@ -66,6 +66,11 @@
         <img src="lines.svg" alt="Line Chart" />
         <p>This chart shows the mean measured time for each function as the input (or the size of the input) increases.</p>
         {{- endif }}
+        {{- if line_chart_tput }}
+        <h3>Throughput Chart</h3>
+        <img src="lines_tput.svg" alt="Line Chart" />
+        <p>This chart shows the mean measured throughput for each function as the input (or the size of the input) increases.</p>
+        {{- endif }}
         {{- for bench in benchmarks }}
         <section class="plots">
             <a href="{bench.path}/report/index.html">

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@
 
 #![deny(missing_docs)]
 #![deny(bare_trait_objects)]
+#![deny(warnings)]
 #![cfg_attr(feature = "real_blackbox", feature(test))]
 #![cfg_attr(
     feature = "cargo-clippy",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,6 @@
 
 #![deny(missing_docs)]
 #![deny(bare_trait_objects)]
-#![deny(warnings)]
 #![cfg_attr(feature = "real_blackbox", feature(test))]
 #![cfg_attr(
     feature = "cargo-clippy",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1223,7 +1223,7 @@ To test that the benchmarks work, run `cargo test --benches`
     ///     // Now we can perform benchmarks with this group
     ///     group.bench_function("Bench 1", |b| b.iter(|| 1 ));
     ///     group.bench_function("Bench 2", |b| b.iter(|| 2 ));
-    ///    
+    ///
     ///     group.finish();
     /// }
     /// criterion_group!(benches, bench_simple);
@@ -1524,6 +1524,18 @@ pub enum Throughput {
     /// collection, but could also be the number of lines of input text or the number of values to
     /// parse.
     Elements(u64),
+}
+
+impl Throughput {
+    /// Given a runtime in ns, return the throughput in bytes or elements per second.
+    fn per_second(&self, runtime: f64) -> f64 {
+        let val = match *self {
+            Throughput::Bytes(bytes) => bytes as f64,
+            Throughput::Elements(elems) => elems as f64,
+        };
+
+        val * (1e9 / runtime)
+    }
 }
 
 /// Axis scaling type

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 
 #![deny(missing_docs)]
 #![deny(bare_trait_objects)]
-#![deny(warnings)]
+//#![deny(warnings)]
 #![cfg_attr(feature = "real_blackbox", feature(test))]
 #![cfg_attr(
     feature = "cargo-clippy",

--- a/src/measurement.rs
+++ b/src/measurement.rs
@@ -127,11 +127,11 @@ impl DurationFormatter {
 
     fn elements_per_second(&self, elems: f64, typical: f64, values: &mut [f64]) -> &'static str {
         let elems_per_second = elems * (1e9 / typical);
-        let (denominator, unit) = if elems_per_second < 1000.0 {
+        let (denominator, unit) = if typical < 1000.0 {
             (1.0, " elem/s")
-        } else if elems_per_second < 1000.0 * 1000.0 {
+        } else if typical < 1000.0 * 1000.0 {
             (1000.0, "Kelem/s")
-        } else if elems_per_second < 1000.0 * 1000.0 * 1000.0 {
+        } else if typical < 1000.0 * 1000.0 * 1000.0 {
             (1000.0 * 1000.0, "Melem/s")
         } else {
             (1000.0 * 1000.0 * 1000.0, "Gelem/s")

--- a/src/plot/summary.rs
+++ b/src/plot/summary.rs
@@ -122,7 +122,7 @@ pub fn line_comparison(
 }
 
 #[cfg_attr(feature = "cargo-clippy", allow(clippy::explicit_counter_loop))]
-pub fn line_comparison_throughput(
+pub fn comparison_throughput(
     formatter: &dyn ValueFormatter,
     title: &str,
     all_curves: &[&(&BenchmarkId, Vec<f64>)],
@@ -190,24 +190,21 @@ pub fn line_comparison_throughput(
                 let x = id.as_number().unwrap();
                 let mut y = [Sample::new(sample).mean()];
                 formatter.scale_throughputs(max, id.throughput.as_ref().unwrap(), &mut y);
+
                 (x, y[0])
             })
             .collect();
 
         tuples.sort_by(|&(ax, _), &(bx, _)| (ax.partial_cmp(&bx).unwrap_or(Ordering::Less)));
         let (xs, ys): (Vec<_>, Vec<_>) = tuples.into_iter().unzip();
-
+        
         let function_name = key.as_ref().map(|string| escape_underscores(string));
 
-        f.plot(Lines { x: &xs, y: &ys }, |c| {
+        f.plot(Points { x: &xs, y: &ys }, |p| {
             if let Some(name) = function_name {
-                c.set(Label(name));
+                p.set(Label(name));
             }
-            c.set(LINEWIDTH)
-                .set(LineType::Solid)
-                .set(COMPARISON_COLORS[i % NUM_COLORS])
-        })
-        .plot(Points { x: &xs, y: &ys }, |p| {
+
             p.set(PointType::FilledCircle)
                 .set(POINT_SIZE)
                 .set(COMPARISON_COLORS[i % NUM_COLORS])

--- a/src/report.rs
+++ b/src/report.rs
@@ -597,19 +597,21 @@ impl Report for CliReport {
             println!(
                 "{}thrpt:  [{} {} {}]",
                 " ".repeat(24),
-                self.faint(
-                    formatter.format_throughput(
-                        throughput,
-                        slope_estimate.confidence_interval.upper_bound
-                    )
-                ),
-                self.bold(formatter.format_throughput(throughput, slope_estimate.point_estimate)),
-                self.faint(
-                    formatter.format_throughput(
-                        throughput,
-                        slope_estimate.confidence_interval.lower_bound
-                    )
-                ),
+                self.faint(formatter.format_throughput(
+                    throughput,
+                    throughput.per_second(slope_estimate.point_estimate),
+                    slope_estimate.confidence_interval.upper_bound
+                )),
+                self.bold(formatter.format_throughput(
+                    throughput,
+                    throughput.per_second(slope_estimate.point_estimate),
+                    slope_estimate.point_estimate
+                )),
+                self.faint(formatter.format_throughput(
+                    throughput,
+                    throughput.per_second(slope_estimate.point_estimate),
+                    slope_estimate.confidence_interval.lower_bound
+                )),
             )
         }
 
@@ -783,8 +785,7 @@ mod test {
 
     #[test]
     fn test_make_filename_safe_respects_character_boundaries() {
-        let input =
-            "✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓";
+        let input = "✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓";
         let safe = make_filename_safe(input);
         assert!(safe.len() < MAX_DIRECTORY_NAME_LEN);
     }


### PR DESCRIPTION
A first version to address  #149. This adds a throughput chart to the summary page.

Some more thoughts:

It was a bit of a nuisance to get the Throughput struct down to the reporting and plotting, maybe there is an easier, better way that I don't know?

Also, plot::line_comparison_throughput is doing unwrap on Option<Throughput> so the caller should check that every BenchmarkId has a throughput (and that its of the same type probably). I can add that if the general direction of this pull request is deemed fine.

Maybe, instead of a line-plot a barchart will work better here?

To test I use: 
```
cargo bench -- from_elem
open target/criterion/report/index.html
```