### PR TITLE
Use OsRng from rand_core instead of deprecated rand_os

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,8 @@ walkdir = "2.2"
 tinytemplate = "1.0"
 cast = "0.2"
 num-traits = "0.2"
-rand_os = "0.2"
 rand_xoshiro = "0.3"
-rand_core = { version = "0.5", default-features = false }
+rand_core = { version = "0.5", default-features = false, features = ["getrandom"] }
 rayon = "1.1"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,6 @@ extern crate csv;
 extern crate itertools;
 extern crate num_traits;
 extern crate rand_core;
-extern crate rand_os;
 extern crate rand_xoshiro;
 extern crate rayon;
 extern crate serde;

--- a/src/stats/rand_util.rs
+++ b/src/stats/rand_util.rs
@@ -1,5 +1,4 @@
-use rand_core::{RngCore, SeedableRng};
-use rand_os::OsRng;
+use rand_core::{OsRng, RngCore, SeedableRng};
 use rand_xoshiro::Xoshiro256StarStar;
 
 use std::cell::RefCell;


### PR DESCRIPTION
Fix #328

Signed-off-by: Robert-André Mauchin <zebob.m@gmail.com>