### PR TITLE
remove deprecated rand_os and added CyclesPerByte measurement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,8 @@ walkdir = "2.2"
 tinytemplate = "1.0"
 cast = "0.2"
 num-traits = "0.2"
-rand_os = "0.2"
 rand_xoshiro = "0.3"
-rand_core = { version = "0.5", default-features = false }
+rand_core = { version = "0.5", default-features = false, features = ["getrandom"] }
 rayon = "1.1"
 
 [dev-dependencies]
@@ -46,6 +45,7 @@ maintenance = { status = "passively-maintained" }
 [features]
 real_blackbox = []
 default = []
+cycles = []
 
 [workspace]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,9 +36,6 @@ extern crate approx;
 #[macro_use]
 extern crate quickcheck;
 
-#[cfg(test)]
-extern crate rand;
-
 #[macro_use]
 extern crate clap;
 
@@ -52,7 +49,6 @@ extern crate csv;
 extern crate itertools;
 extern crate num_traits;
 extern crate rand_core;
-extern crate rand_os;
 extern crate rand_xoshiro;
 extern crate rayon;
 extern crate serde;

--- a/src/stats/rand_util.rs
+++ b/src/stats/rand_util.rs
@@ -1,5 +1,4 @@
-use rand_core::{RngCore, SeedableRng};
-use rand_os::OsRng;
+use rand_core::{RngCore, SeedableRng, OsRng};
 use rand_xoshiro::Xoshiro256StarStar;
 
 use std::cell::RefCell;


### PR DESCRIPTION
Includes #329. I can rebase after it is accepted separately.

The `CyclesPerByte` measurement implementation uses an x86/x86_64 specific intrinsic, so it deserves its own feature in `Cargo.toml` `cycles`. It doesn't ask `cpuid` for support but it'd panic anyway.

Using `CyclesPerByte` displays the `cycles` on all benchmarks, `cpb` for byte-wise throughput benchmarks, and `c/e` for element-wise throughput benchmarks. It would be nicer to measure both `CyclesPerByte` and `WallTime`; should they be measured independently as to not count each-other?