### PR TITLE
Use cargo_metadata to detect target directory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,11 +31,12 @@ num-traits = { version = "0.2", default-features = false }
 oorandom = "11.1"
 rayon = "1.3"
 regex = { version = "1.3", default-features = false, features = ["std"] }
+cargo_metadata = "0.10.0"
 
 [dependencies.plotters]
 version = "^0.2.12"
 default-features = false
-features = ["svg", "area_series", "line_series"] 
+features = ["svg", "area_series", "line_series"]
 
 [dev-dependencies]
 tempfile = "3.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -743,10 +743,12 @@ impl Default for Criterion {
         // - ./target/criterion
         let output_directory = if let Some(value) = std::env::var_os("CRITERION_HOME") {
             PathBuf::from(value)
-        } else if let Some(value) = std::env::var_os("CARGO_TARGET_DIR") {
-            PathBuf::from(value).join("criterion")
         } else {
-            PathBuf::from("target/criterion")
+            let cmd = cargo_metadata::MetadataCommand::new();
+            match cmd.exec() {
+                Ok(metadata) => metadata.target_directory.join("criterion"),
+                Err(_) => PathBuf::from("target/criterion"),
+            }
         };
 
         Criterion {
@@ -1419,7 +1421,7 @@ To test that the benchmarks work, run `cargo test --benches`
     ///     // Now we can perform benchmarks with this group
     ///     group.bench_function("Bench 1", |b| b.iter(|| 1 ));
     ///     group.bench_function("Bench 2", |b| b.iter(|| 2 ));
-    ///    
+    ///
     ///     group.finish();
     /// }
     /// criterion_group!(benches, bench_simple);


### PR DESCRIPTION
This PR uses cargo_metadata to detect target directory instead of `CARGO_TARGET_DIR`.
This will fix  #192.