### PR TITLE
Add missing configuration to criterion-macro output

### DIFF
--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -25,7 +25,7 @@ pub fn criterion(attr: TokenStream, item: TokenStream) -> TokenStream {
         pub fn #wrapped_name() {
             #item
 
-            let mut c = #init;
+            let mut c = #init.configure_from_args();
             #function_name(&mut c);
         }
     );


### PR DESCRIPTION
This also resulted in missing output colorization and missing plots in the HTML report.