### PR TITLE
Update criterion.rs and all examples to Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ walkdir = "2.2"
 tinytemplate = "1.0"
 cast = "0.2"
 num-traits = "0.2"
-rand_os = "0.2"
 rand_xoshiro = "0.3"
 rand_core = { version = "0.5", default-features = false }
 rayon = "1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ cast = "0.2"
 num-traits = "0.2"
 rand_xoshiro = "0.3"
 rand_core = { version = "0.5", default-features = false }
+rand = "0.7"
 rayon = "1.1"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -65,11 +65,7 @@ harness = false
 Next, define a benchmark by creating a file at `$PROJECT/benches/my_benchmark.rs` with the following contents.
 
 ```rust
-#[macro_use]
-extern crate criterion;
-
-use criterion::Criterion;
-use criterion::black_box;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 fn fibonacci(n: u64) -> u64 {
     match n {

--- a/benches/bench_main.rs
+++ b/benches/bench_main.rs
@@ -1,6 +1,4 @@
-#[macro_use]
-extern crate criterion;
-
+use criterion::criterion_main;
 
 mod benchmarks;
 

--- a/benches/bench_main.rs
+++ b/benches/bench_main.rs
@@ -1,6 +1,6 @@
 #[macro_use]
 extern crate criterion;
-extern crate walkdir;
+
 
 mod benchmarks;
 

--- a/benches/benchmarks/compare_functions.rs
+++ b/benches/benchmarks/compare_functions.rs
@@ -1,7 +1,4 @@
-use criterion::BenchmarkId;
-use criterion::Criterion;
-use criterion::Fun;
-use criterion::ParameterizedBenchmark;
+use criterion::{criterion_group, BenchmarkId, Criterion, Fun, ParameterizedBenchmark};
 
 fn fibonacci_slow(n: u64) -> u64 {
     match n {

--- a/benches/benchmarks/custom_measurement.rs
+++ b/benches/benchmarks/custom_measurement.rs
@@ -1,5 +1,8 @@
-use criterion::measurement::{Measurement, ValueFormatter};
-use criterion::{black_box, Criterion, Throughput};
+use criterion::{
+    black_box, criterion_group,
+    measurement::{Measurement, ValueFormatter},
+    Criterion, Throughput,
+};
 use std::time::{Duration, Instant};
 
 struct HalfSecFormatter;

--- a/benches/benchmarks/external_process.py
+++ b/benches/benchmarks/external_process.py
@@ -1,16 +1,17 @@
+import time
 import sys
+
 
 def fibonacci(n):
     if n == 0 or n == 1:
         return 1
-    return fibonacci(n-1) + fibonacci(n-2)
+    return fibonacci(n - 1) + fibonacci(n - 2)
 
-import time
-import sys
 
 MILLIS = 1000
 MICROS = MILLIS * 1000
 NANOS = MICROS * 1000
+
 
 def benchmark():
     depth = int(sys.argv[1])
@@ -30,5 +31,6 @@ def benchmark():
         nanos = int(delta * NANOS)
         print("%d" % nanos)
         sys.stdout.flush()
+
 
 benchmark()

--- a/benches/benchmarks/external_process.rs
+++ b/benches/benchmarks/external_process.rs
@@ -1,9 +1,10 @@
-use criterion::Criterion;
-use std::io::{BufRead, BufReader, Write};
-use std::process::Command;
-use std::process::Stdio;
-use std::str::FromStr;
-use std::time::Duration;
+use criterion::{criterion_group, Criterion};
+use std::{
+    io::{BufRead, BufReader, Write},
+    process::{Command, Stdio},
+    str::FromStr,
+    time::Duration,
+};
 
 fn create_command() -> Command {
     let mut command = Command::new("python3");

--- a/benches/benchmarks/iter_with_large_drop.rs
+++ b/benches/benchmarks/iter_with_large_drop.rs
@@ -1,6 +1,4 @@
-use criterion::Benchmark;
-use criterion::Criterion;
-use criterion::Throughput;
+use criterion::{criterion_group, Benchmark, Criterion, Throughput};
 use std::time::Duration;
 
 const SIZE: usize = 1024 * 1024;

--- a/benches/benchmarks/iter_with_large_setup.rs
+++ b/benches/benchmarks/iter_with_large_setup.rs
@@ -1,6 +1,4 @@
-use criterion::Benchmark;
-use criterion::Criterion;
-use criterion::Throughput;
+use criterion::{criterion_group, Benchmark, Criterion, Throughput};
 use std::time::Duration;
 
 const SIZE: usize = 1024 * 1024;

--- a/benches/benchmarks/iter_with_setup.rs
+++ b/benches/benchmarks/iter_with_setup.rs
@@ -1,4 +1,4 @@
-use criterion::Criterion;
+use criterion::{criterion_group, Criterion};
 
 const SIZE: usize = 1024 * 1024;
 

--- a/benches/benchmarks/measurement_overhead.rs
+++ b/benches/benchmarks/measurement_overhead.rs
@@ -1,4 +1,4 @@
-use criterion::{BatchSize, Criterion};
+use criterion::{criterion_group, BatchSize, Criterion};
 
 fn some_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("overhead");

--- a/benches/benchmarks/special_characters.rs
+++ b/benches/benchmarks/special_characters.rs
@@ -1,4 +1,4 @@
-use criterion::Criterion;
+use criterion::{criterion_group, Criterion};
 
 fn some_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("\"*group/\"");

--- a/benches/benchmarks/with_inputs.rs
+++ b/benches/benchmarks/with_inputs.rs
@@ -1,8 +1,6 @@
 use std::iter;
 
-use criterion::BenchmarkId;
-use criterion::Criterion;
-use criterion::Throughput;
+use criterion::{criterion_group, BenchmarkId, Criterion, Throughput};
 
 fn from_elem(c: &mut Criterion) {
     static KB: usize = 1024;

--- a/book/src/getting_started.md
+++ b/book/src/getting_started.md
@@ -39,13 +39,7 @@ file at `$PROJECT/benches/my_benchmark.rs` with the following contents (see the 
 below for an explanation of this code):
 
 ```rust
-#[macro_use]
-extern crate criterion;
-extern crate mycrate;
-
-use criterion::Criterion;
-use criterion::black_box;
-
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use mycrate::fibonacci;
 
 pub fn criterion_benchmark(c: &mut Criterion) {
@@ -84,13 +78,7 @@ median [25.733 us 25.988 us] med. abs. dev. [234.09 ns 544.07 ns]
 Let's go back and walk through that benchmark code in more detail.
 
 ```rust
-#[macro_use]
-extern crate criterion;
-extern crate mycrate;
-
-use criterion::Criterion;
-use criterion::black_box;
-
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use mycrate::fibonacci;
 ```
 

--- a/book/src/user_guide/bencher_compatibility.md
+++ b/book/src/user_guide/bencher_compatibility.md
@@ -9,10 +9,7 @@ This page shows an example of how to use this crate.
 We'll start with the example benchmark from `bencher`:
 
 ```rust
-#[macro_use]
-extern crate bencher;
-
-use bencher::Bencher;
+use bencher::{benchmark_group, benchmark_main, Bencher};
 
 fn a(bench: &mut Bencher) {
     bench.iter(|| {
@@ -53,15 +50,14 @@ criterion_bencher_compat = "0.3"
 Then we update the benchmark file itself to change:
 
 ```rust
-#[macro_use]
-extern crate bencher;
+use bencher::{benchmark_group, benchmark_main, Bencher};
 ```
 
 To:
 
 ```rust
-#[macro_use]
-extern crate criterion_bencher_compat as bencher;
+use criterion_bencher_compat as bencher;
+use bencher::{benchmark_group, benchmark_main, Bencher};
 ```
 
 That's all! Now just run `cargo bench`:

--- a/book/src/user_guide/comparing_functions.md
+++ b/book/src/user_guide/comparing_functions.md
@@ -5,9 +5,7 @@ graphs to show the differences in performance between them. First, lets create a
 benchmark. We can even combine this with benchmarking over a range of inputs.
 
 ```rust
-#[macro_use]
-extern crate criterion;
-use criterion::Criterion;
+use criterion::{criterion_group, criterion_main, Criterion, BenchmarkId};
 
 fn fibonacci_slow(n: u64) -> u64 {
     match n {

--- a/book/src/user_guide/migrating_from_libtest.md
+++ b/book/src/user_guide/migrating_from_libtest.md
@@ -48,10 +48,7 @@ criterion = "0.3"
 The next step is to update the imports:
 
 ```rust
-#[macro_use]
-extern crate criterion;
-use criterion::Criterion;
-use criterion::black_box;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 ```
 
 Then, we can change the `bench_fib` function. Remove the `#[bench]` and change
@@ -75,10 +72,7 @@ criterion_main!(benches);
 And that's it! The complete migrated benchmark code is below:
 
 ```rust
-#[macro_use]
-extern crate criterion;
-use criterion::Criterion;
-use criterion::black_box;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 fn fibonacci(n: u64) -> u64 {
     match n {

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -217,7 +217,10 @@ fn base_dir_exists(id: &BenchmarkId, baseline: &str, output_directory: &str) -> 
 }
 
 // Performs a simple linear regression on the sample
-fn regression(data: &Data<'_, f64, f64>, config: &BenchmarkConfig) -> (Distribution<f64>, Estimate) {
+fn regression(
+    data: &Data<'_, f64, f64>,
+    config: &BenchmarkConfig,
+) -> (Distribution<f64>, Estimate) {
     let cl = config.confidence_level;
 
     let distribution = elapsed!(

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -217,7 +217,7 @@ fn base_dir_exists(id: &BenchmarkId, baseline: &str, output_directory: &str) -> 
 }
 
 // Performs a simple linear regression on the sample
-fn regression(data: &Data<f64, f64>, config: &BenchmarkConfig) -> (Distribution<f64>, Estimate) {
+fn regression(data: &Data<'_, f64, f64>, config: &BenchmarkConfig) -> (Distribution<f64>, Estimate) {
     let cl = config.confidence_level;
 
     let distribution = elapsed!(

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -250,7 +250,7 @@ where
     pub fn new<S, F>(id: S, f: F) -> Benchmark<M>
     where
         S: Into<String>,
-        F: FnMut(&mut Bencher<M>) + 'static,
+        F: FnMut(&mut Bencher<'_, M>) + 'static,
     {
         Benchmark {
             config: PartialBenchmarkConfig::default(),
@@ -264,7 +264,7 @@ where
     pub fn with_function<S, F>(mut self, id: S, mut f: F) -> Benchmark<M>
     where
         S: Into<String>,
-        F: FnMut(&mut Bencher<M>) + 'static,
+        F: FnMut(&mut Bencher<'_, M>) + 'static,
     {
         let routine = NamedRoutine {
             id: id.into(),
@@ -393,7 +393,7 @@ where
     pub fn new<S, F, I>(id: S, f: F, parameters: I) -> ParameterizedBenchmark<T, M>
     where
         S: Into<String>,
-        F: FnMut(&mut Bencher<M>, &T) + 'static,
+        F: FnMut(&mut Bencher<'_, M>, &T) + 'static,
         I: IntoIterator<Item = T>,
     {
         ParameterizedBenchmark {
@@ -409,7 +409,7 @@ where
     pub fn with_function<S, F>(mut self, id: S, f: F) -> ParameterizedBenchmark<T, M>
     where
         S: Into<String>,
-        F: FnMut(&mut Bencher<M>, &T) + 'static,
+        F: FnMut(&mut Bencher<'_, M>, &T) + 'static,
     {
         let routine = NamedRoutine {
             id: id.into(),

--- a/src/benchmark_group.rs
+++ b/src/benchmark_group.rs
@@ -209,7 +209,7 @@ impl<'a, M: Measurement> BenchmarkGroup<'a, M> {
         self
     }
 
-    pub(crate) fn new(criterion: &mut Criterion<M>, group_name: String) -> BenchmarkGroup<M> {
+    pub(crate) fn new(criterion: &mut Criterion<M>, group_name: String) -> BenchmarkGroup<'_, M> {
         BenchmarkGroup {
             criterion,
             group_name,
@@ -223,7 +223,7 @@ impl<'a, M: Measurement> BenchmarkGroup<'a, M> {
     /// Benchmark the given parameterless function inside this benchmark group.
     pub fn bench_function<ID: IntoBenchmarkId, F>(&mut self, id: ID, mut f: F) -> &mut Self
     where
-        F: FnMut(&mut Bencher<M>),
+        F: FnMut(&mut Bencher<'_, M>),
     {
         self.run_bench(id.into_benchmark_id(), &(), |b, _| f(b));
         self
@@ -237,7 +237,7 @@ impl<'a, M: Measurement> BenchmarkGroup<'a, M> {
         f: F,
     ) -> &mut Self
     where
-        F: FnMut(&mut Bencher<M>, &I),
+        F: FnMut(&mut Bencher<'_, M>, &I),
     {
         self.run_bench(id.into_benchmark_id(), input, f);
         self
@@ -245,7 +245,7 @@ impl<'a, M: Measurement> BenchmarkGroup<'a, M> {
 
     fn run_bench<F, I>(&mut self, id: BenchmarkId, input: &I, f: F)
     where
-        F: FnMut(&mut Bencher<M>, &I),
+        F: FnMut(&mut Bencher<'_, M>, &I),
     {
         let config = self.partial_config.to_complete(&self.criterion.config);
         let report_context = ReportContext {

--- a/src/csv_report.rs
+++ b/src/csv_report.rs
@@ -24,7 +24,7 @@ impl<W: Write> CsvReportWriter<W> {
     fn write_data(
         &mut self,
         id: &BenchmarkId,
-        data: &MeasurementData,
+        data: &MeasurementData<'_>,
         formatter: &dyn ValueFormatter,
     ) -> Result<()> {
         let mut data_scaled: Vec<f64> = data.sample_times().as_ref().into();
@@ -62,7 +62,7 @@ impl FileCsvReport {
         &self,
         path: String,
         id: &BenchmarkId,
-        measurements: &MeasurementData,
+        measurements: &MeasurementData<'_>,
         formatter: &dyn ValueFormatter,
     ) -> Result<()> {
         let writer = Writer::from_path(path)?;
@@ -77,7 +77,7 @@ impl Report for FileCsvReport {
         &self,
         id: &BenchmarkId,
         context: &ReportContext,
-        measurements: &MeasurementData,
+        measurements: &MeasurementData<'_>,
         formatter: &dyn ValueFormatter,
     ) {
         let path = format!(

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,7 +23,7 @@ pub enum Error {
     CsvError(CsvError),
 }
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::AccessError { path, inner } => {
                 write!(f, "Failed to access file {:?}: {}", path, inner)

--- a/src/estimate.rs
+++ b/src/estimate.rs
@@ -14,7 +14,7 @@ pub enum Statistic {
 }
 
 impl fmt::Display for Statistic {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Statistic::Mean => f.pad("mean"),
             Statistic::Median => f.pad("median"),

--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -303,7 +303,7 @@ impl Report for Html {
         &self,
         id: &BenchmarkId,
         report_context: &ReportContext,
-        measurements: &MeasurementData,
+        measurements: &MeasurementData<'_>,
         formatter: &dyn ValueFormatter,
     ) {
         if !report_context.plotting.is_enabled() {
@@ -557,7 +557,7 @@ impl Report for Html {
         let mut groups = id_groups
             .into_iter()
             .map(|(_, group)| BenchmarkGroup::new(output_directory, &group))
-            .collect::<Vec<BenchmarkGroup>>();
+            .collect::<Vec<BenchmarkGroup<'_>>>();
         groups.sort_unstable_by_key(|g| g.group_report.name);
 
         try_else_return!(fs::mkdirp(&format!("{}/report/", output_directory)));
@@ -576,7 +576,7 @@ impl Report for Html {
     }
 }
 impl Html {
-    fn comparison(&self, measurements: &MeasurementData) -> Option<Comparison> {
+    fn comparison(&self, measurements: &MeasurementData<'_>) -> Option<Comparison> {
         if let Some(ref comp) = measurements.comparison {
             let different_mean = comp.p_value < comp.significance_threshold;
             let mean_est = comp.relative_estimates[&Statistic::Mean];
@@ -643,7 +643,7 @@ impl Html {
         id: &BenchmarkId,
         context: &ReportContext,
         formatter: &dyn ValueFormatter,
-        measurements: &MeasurementData,
+        measurements: &MeasurementData<'_>,
     ) {
         let mut gnuplots = vec![
             // Probability density plots

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,28 +36,12 @@ extern crate approx;
 #[macro_use]
 extern crate quickcheck;
 
-
-
-#[macro_use]
-extern crate clap;
+use clap::value_t;
 
 #[macro_use]
 extern crate lazy_static;
-
 use atty;
-
 use criterion_plot;
-
-
-
-
-
-
-
-
-
-
-
 
 #[cfg(feature = "real_blackbox")]
 extern crate test;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,8 +36,7 @@ extern crate approx;
 #[macro_use]
 extern crate quickcheck;
 
-#[cfg(test)]
-extern crate rand;
+
 
 #[macro_use]
 extern crate clap;
@@ -45,20 +44,20 @@ extern crate clap;
 #[macro_use]
 extern crate lazy_static;
 
-extern crate atty;
-extern crate cast;
-extern crate criterion_plot;
-extern crate csv;
-extern crate itertools;
-extern crate num_traits;
-extern crate rand_core;
-extern crate rand_os;
-extern crate rand_xoshiro;
-extern crate rayon;
-extern crate serde;
-extern crate serde_json;
-extern crate tinytemplate;
-extern crate walkdir;
+use atty;
+
+use criterion_plot;
+
+
+
+
+
+
+
+
+
+
+
 
 #[cfg(feature = "real_blackbox")]
 extern crate test;
@@ -159,7 +158,7 @@ where
     /// Create a new `Fun` given a name and a closure
     pub fn new<F>(name: &str, f: F) -> Fun<I, M>
     where
-        F: FnMut(&mut Bencher<M>, &I) + 'static,
+        F: FnMut(&mut Bencher<'_, M>, &I) + 'static,
     {
         let routine = NamedRoutine {
             id: name.to_owned(),
@@ -1229,7 +1228,7 @@ To test that the benchmarks work, run `cargo test --benches`
     /// criterion_group!(benches, bench_simple);
     /// criterion_main!(benches);
     /// ```
-    pub fn benchmark_group<S: Into<String>>(&mut self, group_name: S) -> BenchmarkGroup<M> {
+    pub fn benchmark_group<S: Into<String>>(&mut self, group_name: S) -> BenchmarkGroup<'_, M> {
         BenchmarkGroup::new(self, group_name.into())
     }
 }
@@ -1260,7 +1259,7 @@ where
     /// ```
     pub fn bench_function<F>(&mut self, id: &str, f: F) -> &mut Criterion<M>
     where
-        F: FnMut(&mut Bencher<M>),
+        F: FnMut(&mut Bencher<'_, M>),
     {
         self.benchmark_group(id)
             .bench_function(BenchmarkId::no_function(), f);
@@ -1292,7 +1291,7 @@ where
     /// ```
     pub fn bench_with_input<F, I>(&mut self, id: BenchmarkId, input: &I, f: F) -> &mut Criterion<M>
     where
-        F: FnMut(&mut Bencher<M>, &I),
+        F: FnMut(&mut Bencher<'_, M>, &I),
     {
         // Guaranteed safe because external callers can't create benchmark IDs without a function
         // name or parameter
@@ -1339,7 +1338,7 @@ where
     where
         I: IntoIterator,
         I::Item: fmt::Debug + 'static,
-        F: FnMut(&mut Bencher<M>, &I::Item) + 'static,
+        F: FnMut(&mut Bencher<'_, M>, &I::Item) + 'static,
     {
         self.bench(id, ParameterizedBenchmark::new(id, f, inputs))
     }

--- a/src/plot/distributions.rs
+++ b/src/plot/distributions.rs
@@ -122,7 +122,7 @@ pub(crate) fn abs_distributions(
     id: &BenchmarkId,
     context: &ReportContext,
     formatter: &dyn ValueFormatter,
-    measurements: &MeasurementData,
+    measurements: &MeasurementData<'_>,
     size: Option<Size>,
 ) -> Vec<Child> {
     measurements
@@ -271,7 +271,7 @@ fn rel_distribution(
 pub(crate) fn rel_distributions(
     id: &BenchmarkId,
     context: &ReportContext,
-    _measurements: &MeasurementData,
+    _measurements: &MeasurementData<'_>,
     comparison: &ComparisonData,
     size: Option<Size>,
 ) -> Vec<Child> {

--- a/src/plot/pdf.rs
+++ b/src/plot/pdf.rs
@@ -8,7 +8,7 @@ pub(crate) fn pdf(
     id: &BenchmarkId,
     context: &ReportContext,
     formatter: &dyn ValueFormatter,
-    measurements: &MeasurementData,
+    measurements: &MeasurementData<'_>,
     size: Option<Size>,
 ) -> Child {
     let avg_times = &measurements.avg_times;
@@ -228,7 +228,7 @@ pub(crate) fn pdf_small(
     id: &BenchmarkId,
     context: &ReportContext,
     formatter: &dyn ValueFormatter,
-    measurements: &MeasurementData,
+    measurements: &MeasurementData<'_>,
     size: Option<Size>,
 ) -> Child {
     let avg_times = &*measurements.avg_times;
@@ -287,7 +287,7 @@ pub(crate) fn pdf_small(
 
 fn pdf_comparison_figure(
     formatter: &dyn ValueFormatter,
-    measurements: &MeasurementData,
+    measurements: &MeasurementData<'_>,
     comparison: &ComparisonData,
     size: Option<Size>,
 ) -> Figure {
@@ -365,7 +365,7 @@ pub(crate) fn pdf_comparison(
     id: &BenchmarkId,
     context: &ReportContext,
     formatter: &dyn ValueFormatter,
-    measurements: &MeasurementData,
+    measurements: &MeasurementData<'_>,
     comparison: &ComparisonData,
     size: Option<Size>,
 ) -> Child {
@@ -380,7 +380,7 @@ pub(crate) fn pdf_comparison_small(
     id: &BenchmarkId,
     context: &ReportContext,
     formatter: &dyn ValueFormatter,
-    measurements: &MeasurementData,
+    measurements: &MeasurementData<'_>,
     comparison: &ComparisonData,
     size: Option<Size>,
 ) -> Child {

--- a/src/plot/regression.rs
+++ b/src/plot/regression.rs
@@ -14,7 +14,7 @@ use crate::measurement::ValueFormatter;
 
 fn regression_figure(
     formatter: &dyn ValueFormatter,
-    measurements: &MeasurementData,
+    measurements: &MeasurementData<'_>,
     size: Option<Size>,
 ) -> Figure {
     let slope_estimate = &measurements.absolute_estimates[&Statistic::Slope];
@@ -98,7 +98,7 @@ pub(crate) fn regression(
     id: &BenchmarkId,
     context: &ReportContext,
     formatter: &dyn ValueFormatter,
-    measurements: &MeasurementData,
+    measurements: &MeasurementData<'_>,
     size: Option<Size>,
 ) -> Child {
     let mut figure = regression_figure(formatter, measurements, size);
@@ -118,7 +118,7 @@ pub(crate) fn regression_small(
     id: &BenchmarkId,
     context: &ReportContext,
     formatter: &dyn ValueFormatter,
-    measurements: &MeasurementData,
+    measurements: &MeasurementData<'_>,
     size: Option<Size>,
 ) -> Child {
     let mut figure = regression_figure(formatter, measurements, size);
@@ -131,9 +131,9 @@ pub(crate) fn regression_small(
 
 fn regression_comparison_figure(
     formatter: &dyn ValueFormatter,
-    measurements: &MeasurementData,
+    measurements: &MeasurementData<'_>,
     comparison: &ComparisonData,
-    base_data: &Data<f64, f64>,
+    base_data: &Data<'_, f64, f64>,
     size: Option<Size>,
 ) -> Figure {
     let data = &measurements.data;
@@ -247,9 +247,9 @@ pub(crate) fn regression_comparison(
     id: &BenchmarkId,
     context: &ReportContext,
     formatter: &dyn ValueFormatter,
-    measurements: &MeasurementData,
+    measurements: &MeasurementData<'_>,
     comparison: &ComparisonData,
-    base_data: &Data<f64, f64>,
+    base_data: &Data<'_, f64, f64>,
     size: Option<Size>,
 ) -> Child {
     let mut figure =
@@ -265,9 +265,9 @@ pub(crate) fn regression_comparison_small(
     id: &BenchmarkId,
     context: &ReportContext,
     formatter: &dyn ValueFormatter,
-    measurements: &MeasurementData,
+    measurements: &MeasurementData<'_>,
     comparison: &ComparisonData,
-    base_data: &Data<f64, f64>,
+    base_data: &Data<'_, f64, f64>,
     size: Option<Size>,
 ) -> Child {
     let mut figure =

--- a/src/plot/t_test.rs
+++ b/src/plot/t_test.rs
@@ -10,7 +10,7 @@ use crate::report::{BenchmarkId, ComparisonData, MeasurementData, ReportContext}
 pub(crate) fn t_test(
     id: &BenchmarkId,
     context: &ReportContext,
-    _measurements: &MeasurementData,
+    _measurements: &MeasurementData<'_>,
     comparison: &ComparisonData,
     size: Option<Size>,
 ) -> Child {

--- a/src/report.rs
+++ b/src/report.rs
@@ -783,8 +783,7 @@ mod test {
 
     #[test]
     fn test_make_filename_safe_respects_character_boundaries() {
-        let input =
-            "✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓";
+        let input = "✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓";
         let safe = make_filename_safe(input);
         assert!(safe.len() < MAX_DIRECTORY_NAME_LEN);
     }

--- a/src/report.rs
+++ b/src/report.rs
@@ -224,12 +224,12 @@ impl BenchmarkId {
     }
 }
 impl fmt::Display for BenchmarkId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_title())
     }
 }
 impl fmt::Debug for BenchmarkId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fn format_opt(opt: &Option<String>) -> String {
             match *opt {
                 Some(ref string) => format!("\"{}\"", string),
@@ -285,7 +285,7 @@ pub(crate) trait Report {
         &self,
         _id: &BenchmarkId,
         _context: &ReportContext,
-        _measurements: &MeasurementData,
+        _measurements: &MeasurementData<'_>,
         _formatter: &dyn ValueFormatter,
     ) {
     }
@@ -355,7 +355,7 @@ impl Report for Reports {
         &self,
         id: &BenchmarkId,
         context: &ReportContext,
-        measurements: &MeasurementData,
+        measurements: &MeasurementData<'_>,
         formatter: &dyn ValueFormatter,
     ) {
         for report in &self.reports {
@@ -465,7 +465,7 @@ impl CliReport {
         }
     }
 
-    pub fn outliers(&self, sample: &LabeledSample<f64>) {
+    pub fn outliers(&self, sample: &LabeledSample<'_, f64>) {
         let (los, lom, _, him, his) = sample.count();
         let noutliers = los + lom + him + his;
         let sample_size = sample.len();
@@ -567,7 +567,7 @@ impl Report for CliReport {
         &self,
         id: &BenchmarkId,
         _: &ReportContext,
-        meas: &MeasurementData,
+        meas: &MeasurementData<'_>,
         formatter: &dyn ValueFormatter,
     ) {
         self.text_overwrite();

--- a/src/routine.rs
+++ b/src/routine.rs
@@ -150,7 +150,7 @@ fn recommend_sample_size(target_time: f64, met: f64) -> u64 {
 
 pub struct Function<M: Measurement, F, T>
 where
-    F: FnMut(&mut Bencher<M>, &T),
+    F: FnMut(&mut Bencher<'_, M>, &T),
 {
     f: F,
     // TODO: Is there some way to remove these?
@@ -159,7 +159,7 @@ where
 }
 impl<M: Measurement, F, T> Function<M, F, T>
 where
-    F: FnMut(&mut Bencher<M>, &T),
+    F: FnMut(&mut Bencher<'_, M>, &T),
 {
     pub fn new(f: F) -> Function<M, F, T> {
         Function {
@@ -172,7 +172,7 @@ where
 
 impl<M: Measurement, F, T> Routine<M, T> for Function<M, F, T>
 where
-    F: FnMut(&mut Bencher<M>, &T),
+    F: FnMut(&mut Bencher<'_, M>, &T),
 {
     fn bench(&mut self, m: &M, iters: &[u64], parameter: &T) -> Vec<f64> {
         let f = &mut self.f;

--- a/src/stats/bivariate/mod.rs
+++ b/src/stats/bivariate/mod.rs
@@ -8,7 +8,7 @@ use crate::stats::bivariate::resamples::Resamples;
 use crate::stats::float::Float;
 use crate::stats::tuple::{Tuple, TupledDistributionsBuilder};
 use crate::stats::univariate::Sample;
-use rayon::prelude::*;
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
 /// Bivariate `(X, Y)` data
 ///
@@ -16,10 +16,7 @@ use rayon::prelude::*;
 ///
 /// - No `NaN`s in the data
 /// - At least two data points in the set
-pub struct Data<'a, X, Y>(&'a [X], &'a [Y])
-where
-    X: 'a,
-    Y: 'a;
+pub struct Data<'a, X, Y>(&'a [X], &'a [Y]);
 
 impl<'a, X, Y> Copy for Data<'a, X, Y> {}
 
@@ -70,8 +67,7 @@ where
     /// - Memory: `O(nresamples)`
     pub fn bootstrap<T, S>(&self, nresamples: usize, statistic: S) -> T::Distributions
     where
-        S: Fn(Data<X, Y>) -> T,
-        S: Sync,
+        S: Fn(Data<X, Y>) -> T + Sync,
         T: Tuple + Send,
         T::Distributions: Send,
         T::Builder: Send,

--- a/src/stats/bivariate/regression.rs
+++ b/src/stats/bivariate/regression.rs
@@ -17,7 +17,7 @@ where
     /// squares
     ///
     /// - Time: `O(length)`
-    pub fn fit(data: &Data<A, A>) -> Slope<A> {
+    pub fn fit(data: &Data<'_, A, A>) -> Slope<A> {
         let xs = data.0;
         let ys = data.1;
 
@@ -30,7 +30,7 @@ where
     /// Computes the goodness of fit (coefficient of determination) for this data set
     ///
     /// - Time: `O(length)`
-    pub fn r_squared(&self, data: &Data<A, A>) -> A {
+    pub fn r_squared(&self, data: &Data<'_, A, A>) -> A {
         let _0 = A::cast(0);
         let _1 = A::cast(1);
         let m = self.0;

--- a/src/stats/bivariate/resamples.rs
+++ b/src/stats/bivariate/resamples.rs
@@ -28,7 +28,7 @@ where
         }
     }
 
-    pub fn next(&mut self) -> Data<X, Y> {
+    pub fn next(&mut self) -> Data<'_, X, Y> {
         let n = self.data.0.len();
         let rng = &mut self.rng;
 

--- a/src/stats/rand_util.rs
+++ b/src/stats/rand_util.rs
@@ -1,4 +1,5 @@
-use rand_core::{OsRng, RngCore, SeedableRng};
+use rand::rngs::OsRng;
+use rand_core::{RngCore, SeedableRng};
 use rand_xoshiro::Xoshiro256StarStar;
 
 use std::cell::RefCell;

--- a/src/stats/rand_util.rs
+++ b/src/stats/rand_util.rs
@@ -1,5 +1,4 @@
-use rand_core::{RngCore, SeedableRng};
-use rand_os::OsRng;
+use rand_core::{OsRng, RngCore, SeedableRng};
 use rand_xoshiro::Xoshiro256StarStar;
 
 use std::cell::RefCell;

--- a/src/stats/univariate/kde/mod.rs
+++ b/src/stats/univariate/kde/mod.rs
@@ -10,7 +10,7 @@ use rayon::prelude::*;
 /// Univariate kernel density estimator
 pub struct Kde<'a, A, K>
 where
-    A: 'a + Float,
+    A: Float,
     K: Kernel<A>,
 {
     bandwidth: A,

--- a/src/stats/univariate/mod.rs
+++ b/src/stats/univariate/mod.rs
@@ -34,8 +34,7 @@ pub fn bootstrap<A, B, T, S>(
 where
     A: Float,
     B: Float,
-    S: Fn(&Sample<A>, &Sample<B>) -> T,
-    S: Sync,
+    S: Fn(&Sample<A>, &Sample<B>) -> T + Sync,
     T: Tuple + Send,
     T::Distributions: Send,
     T::Builder: Send,

--- a/src/stats/univariate/outliers/tukey.rs
+++ b/src/stats/univariate/outliers/tukey.rs
@@ -58,7 +58,7 @@ use self::Label::*;
 #[derive(Clone, Copy)]
 pub struct LabeledSample<'a, A>
 where
-    A: 'a + Float,
+    A: Float,
 {
     fences: (A, A, A, A),
     sample: &'a Sample<A>,
@@ -170,7 +170,7 @@ where
 /// Iterator over the labeled data
 pub struct Iter<'a, A>
 where
-    A: 'a + Float,
+    A: Float,
 {
     fences: (A, A, A, A),
     iter: slice::Iter<'a, A>,
@@ -267,7 +267,7 @@ impl Label {
 /// Classifies the sample, and returns a labeled sample.
 ///
 /// - Time: `O(N log N) where N = length`
-pub fn classify<A>(sample: &Sample<A>) -> LabeledSample<A>
+pub fn classify<A>(sample: &Sample<A>) -> LabeledSample<'_, A>
 where
     A: Float,
     usize: cast::From<A, Output = Result<usize, cast::Error>>,

--- a/src/stats/univariate/resamples.rs
+++ b/src/stats/univariate/resamples.rs
@@ -6,7 +6,7 @@ use crate::stats::univariate::Sample;
 
 pub struct Resamples<'a, A>
 where
-    A: 'a + Float,
+    A: Float,
 {
     range: Range,
     rng: Rng,

--- a/src/stats/univariate/sample.rs
+++ b/src/stats/univariate/sample.rs
@@ -204,10 +204,8 @@ where
     /// - Memory: `O(nresamples)`
     pub fn bootstrap<T, S>(&self, nresamples: usize, statistic: S) -> T::Distributions
     where
-        S: Fn(&Sample<A>) -> T,
-        S: Sync,
-        T: Tuple,
-        T: Send,
+        S: Fn(&Sample<A>) -> T + Sync,
+        T: Tuple + Send,
         T::Distributions: Send,
         T::Builder: Send,
     {

--- a/tests/criterion_tests.rs
+++ b/tests/criterion_tests.rs
@@ -1,8 +1,8 @@
 #[macro_use]
 extern crate criterion;
-extern crate serde_json;
-extern crate tempdir;
-extern crate walkdir;
+use serde_json;
+
+
 
 use criterion::profiler::Profiler;
 use criterion::{

--- a/tests/criterion_tests.rs
+++ b/tests/criterion_tests.rs
@@ -1,12 +1,9 @@
-#[macro_use]
-extern crate criterion;
+use criterion;
 use serde_json;
 
-
-
-use criterion::profiler::Profiler;
 use criterion::{
-    BatchSize, Benchmark, BenchmarkId, Criterion, Fun, ParameterizedBenchmark, Throughput,
+    criterion_group, criterion_main, profiler::Profiler, BatchSize, Benchmark, BenchmarkId,
+    Criterion, Fun, ParameterizedBenchmark, Throughput,
 };
 use serde_json::value::Value;
 use std::cell::{Cell, RefCell};
@@ -448,7 +445,7 @@ fn test_benchmark_group_without_input() {
 }
 
 mod macros {
-    use super::criterion;
+    use super::{criterion, criterion_group, criterion_main};
 
     #[test]
     #[should_panic(expected = "group executed")]
@@ -509,7 +506,6 @@ mod macros {
 
         test_group();
     }
-
 }
 
 struct TestProfiler {


### PR DESCRIPTION
The 2018 edition module syntax is quite a bit easier to follow, and de-obfuscates macro imports. This is especially helpful for newcomers. All quickstart and book examples have been updated to use `edition="2018"` style.

Edit: This also includes a fixed missing `BenchmarkId` import in the `comparing_functions.md` file, which was separately raised in #346 