### PR TITLE
Make command line note more obvious

### DIFF
--- a/book/src/user_guide/command_line_options.md
+++ b/book/src/user_guide/command_line_options.md
@@ -1,5 +1,7 @@
 # Command-Line Options
 
+**Note: If `cargo bench` fails with an error message about an unknown argument, see [the FAQ](../faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options).**
+
 Criterion.rs benchmarks accept a number of custom command-line parameters. This
 is a list of the most common options. Run `cargo bench -- -h` to see a full
 list.
@@ -13,10 +15,6 @@ would only run benchmarks whose ID contains the string `fib_20`
 * To iterate each benchmark for a fixed length of time without saving, analyzing or plotting the results, use `cargo bench -- --profile-time <num_seconds>`. This is useful when profiling the benchmarks. It reduces the amount of unrelated clutter in the profiling results and prevents Criterion.rs' normal dynamic sampling logic from greatly increasing the runtime of the benchmarks.
 * To save a baseline, use `cargo bench -- --save-baseline <name>`. To compare against an existing baseline, use `cargo bench -- --baseline <name>`. For more on baselines, see below.
 * To test that the benchmarks run successfully without performing the measurement or analysis (eg. in a CI setting), use `cargo test --benches`.
-
-### Note:
-
-If `cargo bench` fails with an error message about an unknown argument, see [the FAQ](../faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options).
 
 ## Baselines
 


### PR DESCRIPTION
I couldn't figure out a way to make it red unfortunately.