### PR TITLE
Set `default-features = false` for  `num-traits`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ csv = "1.1"
 walkdir = "2.3"
 tinytemplate = "1.0"
 cast = "0.2"
-num-traits = "0.2"
+num-traits = { version = "0.2", default-features = false }
 oorandom = "11.1"
 rayon = "1.3"
 regex = { version = "1.3", default-features = false, features = ["std"] }


### PR DESCRIPTION
Hi!

[We're](https://github.com/scipr-lab/zexe/pull/76#issuecomment-579924945) running into https://github.com/rust-lang/cargo/issues/4866 because `criterion` uses `num-traits` with the default features, which turns off `no-std` mode. This PR turns off the default features and (hopefully) fixes that. Thanks! 