### PR TITLE
Fix homebrew install in Gnuplot builds

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -10,7 +10,6 @@ if [ "$DOCS" = "yes" ]; then
 fi
 
 if [ "$TRAVIS_OS_NAME" = "osx" ] && [ "$GNUPLOT" = "yes" ]; then
-    brew update
     brew install gnuplot
 fi
 

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -10,6 +10,7 @@ if [ "$DOCS" = "yes" ]; then
 fi
 
 if [ "$TRAVIS_OS_NAME" = "osx" ] && [ "$GNUPLOT" = "yes" ]; then
+    brew unlink python@2 # because we're installing python3 and they both want to install stuff under /usr/local/Frameworks/Python.framework/
     brew install gnuplot
 fi
 


### PR DESCRIPTION
Not quite sure when the `brew update` was needed, but it doesn't seem to be required now. More importantly, the core problem was that `python@2` was already linked, and we need to unlink it to make the homebrew install work properly as we're installing Python 3 as part of the dependencies.