### PR TITLE
Use a subtractive timing model in iter_batched{,_ref}

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -516,11 +516,11 @@ impl<'a, M: Measurement> Bencher<'a, M> {
             while iteration_counter < self.iters {
                 let batch_size = ::std::cmp::min(batch_size, self.iters - iteration_counter);
 
-                let inputs = black_box((0..batch_size).map(|_| setup()).collect::<Vec<_>>());
+                let mut inputs = black_box((0..batch_size).map(|_| setup()).collect::<Vec<_>>());
                 let mut outputs = Vec::with_capacity(batch_size as usize);
 
                 let start = self.measurement.start();
-                outputs.extend(inputs.into_iter().map(&mut routine));
+                outputs.extend(inputs.drain(..).map(&mut routine));
                 let end = self.measurement.end(start);
                 self.value = self.measurement.add(&self.value, &end);
 

--- a/src/routine.rs
+++ b/src/routine.rs
@@ -195,6 +195,7 @@ where
             iterated: false,
             iters: 0,
             value: m.zero(),
+            overhead: m.zero(),
             measurement: m,
             elapsed_time: Duration::from_millis(0),
         };
@@ -205,7 +206,7 @@ where
                 b.iters = *iters;
                 (*f)(&mut b, parameter);
                 b.assert_iterated();
-                m.to_f64(&b.value)
+                m.to_f64(&b.value) - m.to_f64(&b.overhead)
             })
             .collect()
     }
@@ -216,6 +217,7 @@ where
             iterated: false,
             iters: 1,
             value: m.zero(),
+            overhead: m.zero(),
             measurement: m,
             elapsed_time: Duration::from_millis(0),
         };


### PR DESCRIPTION
See #376. This increases variance by doubling the number of measurements, but removes the bias due to iteration and measurement (per-batch) overhead. `iter_batched` already is using more measurements to reduce bias, so this seems reasonable.

This is based on #384 because I thought of that first and it also is about removing bias from those functions.

I'm a bit confused about what the correct thing to put in the `Timing model` documentation section is. I adjusted it to describe the expectation of the recorded `value - overhead`, which seemed like the most useful interpretation that fits the existing documentation, but `O::drop` was in the documentation for `iter_batched`, yet the drop of the output is very carefully *not* part of what is measured. Also, only `iter` seems to mention the `Range::next` overhead.