### PR TITLE
Add reporter format with bencher support

### DIFF
--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -306,6 +306,7 @@ impl<M: Measurement> BenchmarkDefinition<M> for Benchmark<M> {
             output_directory: c.output_directory.clone(),
             plot_config: self.config.plot_config.clone(),
             test_mode: c.test_mode,
+            reporter: c.reporter.clone(),
         };
 
         let config = self.config.to_complete(&c.config);
@@ -455,6 +456,7 @@ where
             output_directory: c.output_directory.clone(),
             plot_config: self.config.plot_config.clone(),
             test_mode: c.test_mode,
+            reporter: c.reporter.clone(),
         };
 
         let config = self.config.to_complete(&c.config);

--- a/src/benchmark_group.rs
+++ b/src/benchmark_group.rs
@@ -270,6 +270,7 @@ impl<'a, M: Measurement> BenchmarkGroup<'a, M> {
             output_directory: self.criterion.output_directory.clone(),
             plot_config: self.partial_config.plot_config.clone(),
             test_mode: self.criterion.test_mode,
+            reporter: self.criterion.reporter.clone(),
         };
 
         let mut id = InternalBenchmarkId::new(
@@ -331,6 +332,7 @@ impl<'a, M: Measurement> Drop for BenchmarkGroup<'a, M> {
                 output_directory: self.criterion.output_directory.clone(),
                 plot_config: self.partial_config.plot_config.clone(),
                 test_mode: self.criterion.test_mode,
+                reporter: self.criterion.reporter.clone(),
             };
 
             self.criterion.report.summarize(

--- a/src/format.rs
+++ b/src/format.rs
@@ -72,6 +72,30 @@ pub fn iter_count(iterations: u64) -> String {
     }
 }
 
+pub fn thousands(mut n: usize) -> String {
+    use std::fmt::Write;
+
+    let mut output = String::new();
+    let mut trailing = false;
+    for &pow in &[9, 6, 3, 0] {
+        let base = 10_usize.pow(pow);
+        if pow == 0 || trailing || n / base != 0 {
+            if !trailing {
+                output.write_fmt(format_args!("{}", n / base)).unwrap();
+            } else {
+                output.write_fmt(format_args!("{:03}", n / base)).unwrap();
+            }
+            if pow != 0 {
+                output.push(',');
+            }
+            trailing = true;
+        }
+        n %= base;
+    }
+
+    output
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -675,6 +675,7 @@ pub struct Criterion<M: Measurement = WallTime> {
     plotting_enabled: bool,
     filter: Option<Regex>,
     report: Box<dyn Report>,
+    reporter: String,
     output_directory: String,
     baseline_directory: String,
     baseline: Baseline,
@@ -725,6 +726,7 @@ impl Default for Criterion {
             plotting_enabled: true,
             filter: None,
             report: Box::new(Reports::new(reports)),
+            reporter: "criterion".to_owned(),
             baseline_directory: "base".to_owned(),
             baseline: Baseline::Save,
             profile_time: None,
@@ -750,6 +752,7 @@ impl<M: Measurement> Criterion<M> {
             plotting_enabled: self.plotting_enabled,
             filter: self.filter,
             report: self.report,
+            reporter: self.reporter,
             baseline_directory: self.baseline_directory,
             baseline: self.baseline,
             profile_time: self.profile_time,
@@ -1013,6 +1016,7 @@ impl<M: Measurement> Criterion<M> {
             output_directory: self.output_directory.clone(),
             plot_config: PlotConfiguration::default(),
             test_mode: self.test_mode,
+            reporter: self.reporter.clone(),
         };
 
         self.report.final_summary(&report_context);
@@ -1107,6 +1111,12 @@ impl<M: Measurement> Criterion<M> {
                  .takes_value(true)
                  .possible_values(&["gnuplot", "plotters"])
                  .help("Set the plotting backend. By default, Criterion will use the gnuplot backend if gnuplot is available, or the plotters backend if it isn't."))
+            .arg(Arg::with_name("reporter")
+                 .short("R")
+                 .long("reporter")
+                 .default_value("criterion")
+                 .possible_values(&["criterion", "bencher"])
+                 .help("Set the CLI report format."))
             .arg(Arg::with_name("version")
                 .hidden(true)
                 .short("V")
@@ -1163,6 +1173,10 @@ To test that the benchmarks work, run `cargo test --benches`
         if let Some(dir) = matches.value_of("baseline") {
             self.baseline = Baseline::Compare;
             self.baseline_directory = dir.to_owned();
+        }
+
+        if let Some(reporter) = matches.value_of("reporter") {
+            self.reporter = reporter.to_owned();
         }
 
         let mut reports: Vec<Box<dyn Report>> = vec![];


### PR DESCRIPTION
This allows us an option print bencher type format on CLI

```
$ cargo bench -- -R bencher
   Compiling criterion v0.3.1 (/Users/pksunkara/Coding/clap-rs/criterion.rs)
   Compiling clap v3.0.0-beta.1 (/Users/pksunkara/Coding/clap-rs/clap)
    Finished bench [optimized] target(s) in 1m 15s
     Running target/release/deps/01_default-439bccc0e739a77b
Gnuplot not found, using plotters backend
test build_empty_app ... bench:        135 ns/iter (+/- 0)                                 
test parse_empty_app ... bench:      1,940 ns/iter (+/- 10)  
```