### PR TITLE
Avoid panic if environment contains non-UTF8 var

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ pub use crate::benchmark::{Benchmark, BenchmarkDefinition, ParameterizedBenchmar
 pub use crate::benchmark_group::{BenchmarkGroup, BenchmarkId};
 
 lazy_static! {
-    static ref DEBUG_ENABLED: bool = { std::env::vars().any(|(key, _)| key == "CRITERION_DEBUG") };
+    static ref DEBUG_ENABLED: bool = { std::env::var("CRITERION_DEBUG").is_ok() };
     static ref GNUPLOT_VERSION: Result<Version, VersionError> = { criterion_plot::version() };
     static ref DEFAULT_PLOTTING_BACKEND: PlottingBackend = {
         match &*GNUPLOT_VERSION {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -706,8 +706,17 @@ impl Default for Criterion {
         reports.push(Box::new(FileCsvReport));
 
         let output_directory =
-            match std::env::vars().find(|&(ref key, _)| key == "CARGO_TARGET_DIR") {
-                Some((_, value)) => format!("{}/criterion", value),
+            match std::env::vars_os().find(|&(ref key, _)| key == "CARGO_TARGET_DIR") {
+                Some((_, value)) => {
+                    // TODO: The target directory may be non-utf8 and yet still be valid.
+                    // To deal with this, we should ideally use PathBuf instead of String
+                    // to store paths in the `Criterion` struct, but it is unclear to me
+                    // if this would entail a breaking change.
+                    let value = value
+                        .into_string()
+                        .expect("CARGO_TARGET_DIR must be a valid UTF-8 path");
+                    format!("{}/criterion", value)
+                },
                 None => "target/criterion".to_owned(),
             };
 


### PR DESCRIPTION
I wanted to use google's CPU profiler with `criterion`, but I often find it very practical to just add it using `LD_PRELOAD` instead of linking it into the library. This normally works rather well. However, it turns out that `cpuprofiler` actually clobbers the environment variable `CPUPROFILE` instead of just reading it (see here: https://github.com/gperftools/gperftools/blob/f47a52ce85c3d8d559aaae7b7a426c359fbca225/src/base/sysinfo.cc#L209), resulting in a non-utf8 variable. This in turn makes `std::env::vars` panic when iterating, and consequently `criterion` panics as well.

`vars` is used two places in `criterion`: one to determine if we should enable debugging, and one for determining the cargo target directory. Fixing the first one is easy. A proper fix for the second instance would require us to change all paths used in the `Criterion` struct from `String` to `PathBuf`. I have not done this in this PR: I could do so, but I thought I'd ask your opinion first. Instead, as a hotfix, I've made sure that we don't panic if the environment contains an unrelated environment variable that is not UTF-8 compatible.