### PR TITLE
Lint fixes

### DIFF
--- a/benches/benchmarks/iter_with_large_setup.rs
+++ b/benches/benchmarks/iter_with_large_setup.rs
@@ -8,10 +8,7 @@ fn large_setup(c: &mut Criterion) {
         "iter_with_large_setup",
         Benchmark::new("large_setup", |b| {
             // NOTE: iter_with_large_setup is deprecated. Use iter_batched instead.
-            b.iter_with_large_setup(
-                || (0..SIZE).map(|i| i as u8).collect::<Vec<_>>(),
-                |v| v.clone(),
-            )
+            b.iter_with_large_setup(|| (0..SIZE).map(|i| i as u8).collect::<Vec<_>>(), |v| v)
         })
         .throughput(Throughput::Bytes(SIZE as u64)),
     );

--- a/benches/benchmarks/iter_with_setup.rs
+++ b/benches/benchmarks/iter_with_setup.rs
@@ -4,10 +4,7 @@ const SIZE: usize = 1024 * 1024;
 
 fn setup(c: &mut Criterion) {
     c.bench_function("iter_with_setup", |b| {
-        b.iter_with_setup(
-            || (0..SIZE).map(|i| i as u8).collect::<Vec<_>>(),
-            |v| v.clone(),
-        )
+        b.iter_with_setup(|| (0..SIZE).map(|i| i as u8).collect::<Vec<_>>(), |v| v)
     });
 }
 

--- a/src/csv_report.rs
+++ b/src/csv_report.rs
@@ -30,14 +30,14 @@ impl<W: Write> CsvReportWriter<W> {
         let mut data_scaled: Vec<f64> = data.sample_times().as_ref().into();
         let unit = formatter.scale_for_machines(&mut data_scaled);
         let group = id.group_id.as_str();
-        let function = id.function_id.as_ref().map(String::as_str);
-        let value = id.value_str.as_ref().map(String::as_str);
+        let function = id.function_id.as_deref();
+        let value = id.value_str.as_deref();
         let (throughput_num, throughput_type) = match id.throughput {
             Some(Throughput::Bytes(bytes)) => (Some(format!("{}", bytes)), Some("bytes")),
             Some(Throughput::Elements(elems)) => (Some(format!("{}", elems)), Some("elements")),
             None => (None, None),
         };
-        let throughput_num = throughput_num.as_ref().map(String::as_str);
+        let throughput_num = throughput_num.as_deref();
 
         for (count, measured_value) in data.iter_counts().iter().zip(data_scaled.into_iter()) {
             let row = CsvRow {

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,6 +1,6 @@
 use serde::de::DeserializeOwned;
 use serde::Serialize;
-use serde_json;
+
 use std::ffi::OsStr;
 use std::fs::{self, File};
 use std::io::Read;

--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -188,8 +188,8 @@ impl<'a> BenchmarkGroup<'a> {
         let mut individual_links = HashMap::with_capacity(ids.len());
 
         for id in ids.iter() {
-            let function_id = id.function_id.as_ref().map(String::as_str);
-            let value = id.value_str.as_ref().map(String::as_str);
+            let function_id = id.function_id.as_deref();
+            let value = id.value_str.as_deref();
 
             let individual_link = ReportLink::individual(output_directory, id);
 
@@ -475,17 +475,13 @@ impl Report for Html {
         // First sort the ids/data by value.
         // If all of the value strings can be parsed into a number, sort/dedupe
         // numerically. Otherwise sort lexicographically.
-        let all_values_numeric = all_data.iter().all(|(ref id, _)| {
-            id.value_str
-                .as_ref()
-                .map(String::as_str)
-                .and_then(try_parse)
-                .is_some()
-        });
+        let all_values_numeric = all_data
+            .iter()
+            .all(|(ref id, _)| id.value_str.as_deref().and_then(try_parse).is_some());
         if all_values_numeric {
             all_data.sort_unstable_by(|(a, _), (b, _)| {
-                let num1 = a.value_str.as_ref().map(String::as_str).and_then(try_parse);
-                let num2 = b.value_str.as_ref().map(String::as_str).and_then(try_parse);
+                let num1 = a.value_str.as_deref().and_then(try_parse);
+                let num2 = b.value_str.as_deref().and_then(try_parse);
 
                 num1.partial_cmp(&num2).unwrap_or(Ordering::Less)
             });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,8 +41,6 @@ use regex::Regex;
 
 #[macro_use]
 extern crate lazy_static;
-use atty;
-use criterion_plot;
 
 #[cfg(feature = "real_blackbox")]
 extern crate test;

--- a/src/report.rs
+++ b/src/report.rs
@@ -803,7 +803,7 @@ mod test {
         assert_eq!("group/function/value_2", new_id.as_directory_name());
         directories.insert(new_id.as_directory_name().to_owned());
 
-        new_id = existing_id.clone();
+        new_id = existing_id;
         new_id.ensure_directory_name_unique(&directories);
         assert_eq!("group/function/value_3", new_id.as_directory_name());
         directories.insert(new_id.as_directory_name().to_owned());

--- a/src/stats/bivariate/mod.rs
+++ b/src/stats/bivariate/mod.rs
@@ -107,7 +107,7 @@ where
 }
 
 /// Iterator over `Data`
-pub struct Pairs<'a, X: 'a, Y: 'a> {
+pub struct Pairs<'a, X, Y> {
     data: Data<'a, X, Y>,
     state: usize,
 }

--- a/src/stats/bivariate/resamples.rs
+++ b/src/stats/bivariate/resamples.rs
@@ -4,8 +4,8 @@ use crate::stats::rand_util::{new_rng, Rng};
 
 pub struct Resamples<'a, X, Y>
 where
-    X: 'a + Float,
-    Y: 'a + Float,
+    X: Float,
+    Y: Float,
 {
     rng: Rng,
     data: (&'a [X], &'a [Y]),
@@ -15,8 +15,8 @@ where
 #[cfg_attr(feature = "cargo-clippy", allow(clippy::should_implement_trait))]
 impl<'a, X, Y> Resamples<'a, X, Y>
 where
-    X: 'a + Float,
-    Y: 'a + Float,
+    X: Float,
+    Y: Float,
 {
     pub fn new(data: Data<'a, X, Y>) -> Resamples<'a, X, Y> {
         Resamples {

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -20,7 +20,6 @@ use std::ops::Deref;
 
 use crate::stats::float::Float;
 use crate::stats::univariate::Sample;
-use cast;
 
 /// The bootstrap distribution of some parameter
 pub struct Distribution<A>(Box<[A]>);

--- a/src/stats/univariate/kde/mod.rs
+++ b/src/stats/univariate/kde/mod.rs
@@ -20,7 +20,7 @@ where
 
 impl<'a, A, K> Kde<'a, A, K>
 where
-    A: 'a + Float,
+    A: Float,
     K: Kernel<A>,
 {
     /// Creates a new kernel density estimator from the `sample`, using a kernel and estimating

--- a/src/stats/univariate/outliers/tukey.rs
+++ b/src/stats/univariate/outliers/tukey.rs
@@ -43,7 +43,6 @@ use std::slice;
 
 use crate::stats::float::Float;
 use crate::stats::univariate::Sample;
-use cast;
 
 use self::Label::*;
 

--- a/src/stats/univariate/resamples.rs
+++ b/src/stats/univariate/resamples.rs
@@ -16,7 +16,7 @@ where
 #[cfg_attr(feature = "cargo-clippy", allow(clippy::should_implement_trait))]
 impl<'a, A> Resamples<'a, A>
 where
-    A: 'a + Float,
+    A: Float,
 {
     pub fn new(sample: &'a Sample<A>) -> Resamples<'a, A> {
         let slice = sample;

--- a/src/stats/univariate/sample.rs
+++ b/src/stats/univariate/sample.rs
@@ -4,7 +4,7 @@ use crate::stats::float::Float;
 use crate::stats::tuple::{Tuple, TupledDistributionsBuilder};
 use crate::stats::univariate::Percentiles;
 use crate::stats::univariate::Resamples;
-use cast;
+
 use rayon::prelude::*;
 
 /// A collection of data points drawn from a population


### PR DESCRIPTION
The first commit fixes a warning that prevented building on current nightlies.
The rest add fixes for some other clippy and edition lints.