### PR TITLE
Upgrade to itertools 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["book/*"]
 [dependencies]
 lazy_static = "1.4"
 criterion-plot = { path="plot", version="0.4.1" }
-itertools = "0.8"
+itertools = "0.9"
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"

--- a/plot/Cargo.toml
+++ b/plot/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 cast = "0.2"
-itertools = "0.8"
+itertools = "0.9"
 
 [dev-dependencies]
 itertools-num = "0.1"


### PR DESCRIPTION
There are no changes in this version of itertools that are meaningful to
Criterion.rs, but staying up to date helps downstreams eliminate
duplicate dependencies from their trees.

Note that itertools 0.9 bumps itertools's MSRV to 1.32, but Criterion.rs
already has a more restrictive MSRV (1.33).