### PR TITLE
Allow dynamically sized parameter as input

### DIFF
--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -34,7 +34,7 @@ macro_rules! elapsed {
 mod compare;
 
 // Common analysis procedure
-pub(crate) fn common<M: Measurement, T>(
+pub(crate) fn common<M: Measurement, T: ?Sized>(
     id: &BenchmarkId,
     routine: &mut dyn Routine<M, T>,
     config: &BenchmarkConfig,

--- a/src/benchmark_group.rs
+++ b/src/benchmark_group.rs
@@ -256,6 +256,7 @@ impl<'a, M: Measurement> BenchmarkGroup<'a, M> {
     ) -> &mut Self
     where
         F: FnMut(&mut Bencher<'_, M>, &I),
+        I: ?Sized,
     {
         self.run_bench(id.into_benchmark_id(), input, f);
         self
@@ -264,6 +265,7 @@ impl<'a, M: Measurement> BenchmarkGroup<'a, M> {
     fn run_bench<F, I>(&mut self, id: BenchmarkId, input: &I, f: F)
     where
         F: FnMut(&mut Bencher<'_, M>, &I),
+        I: ?Sized,
     {
         let config = self.partial_config.to_complete(&self.criterion.config);
         let report_context = ReportContext {

--- a/src/routine.rs
+++ b/src/routine.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 /// PRIVATE
-pub trait Routine<M: Measurement, T> {
+pub trait Routine<M: Measurement, T: ?Sized> {
     /// PRIVATE
     fn bench(&mut self, m: &M, iters: &[u64], parameter: &T) -> Vec<f64>;
     /// PRIVATE
@@ -165,6 +165,7 @@ fn recommend_sample_size(target_time: f64, met: f64) -> u64 {
 pub struct Function<M: Measurement, F, T>
 where
     F: FnMut(&mut Bencher<'_, M>, &T),
+    T: ?Sized,
 {
     f: F,
     // TODO: Is there some way to remove these?
@@ -174,6 +175,7 @@ where
 impl<M: Measurement, F, T> Function<M, F, T>
 where
     F: FnMut(&mut Bencher<'_, M>, &T),
+    T: ?Sized,
 {
     pub fn new(f: F) -> Function<M, F, T> {
         Function {
@@ -187,6 +189,7 @@ where
 impl<M: Measurement, F, T> Routine<M, T> for Function<M, F, T>
 where
     F: FnMut(&mut Bencher<'_, M>, &T),
+    T: ?Sized,
 {
     fn bench(&mut self, m: &M, iters: &[u64], parameter: &T) -> Vec<f64> {
         let f = &mut self.f;


### PR DESCRIPTION
All functions with user supplied paramter only deal with it behind a reference. This allows passing a slice or a `&str` as a parameter.