### PR TITLE
Make much more functionality optional.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ serde_json = "1.0"
 serde_derive = "1.0"
 atty = "0.2"
 clap = { version = "2.33", default-features = false }
-csv = "1.1"
+csv = { version = "1.1", optional = true }
 walkdir = "2.3"
 tinytemplate = { version = "1.0", optional = true }
 cast = "0.2"
@@ -52,7 +52,7 @@ maintenance = { status = "passively-maintained" }
 real_blackbox = []
 filter_regex = ["regex"]
 plotting = ["criterion-plot", "itertools", "tinytemplate", "plotters"]
-default = ["filter_regex", "plotting"]
+default = ["filter_regex", "plotting", "csv"]
 
 [workspace]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ cast = "0.2"
 num-traits = { version = "0.2", default-features = false }
 oorandom = "11.1"
 rayon = "1.3"
-regex = { version = "1.3", default-features = false, features = ["std"] }
+regex = { version = "1.3", default-features = false, features = ["std"], optional = true }
 
 [dependencies.plotters]
 version = "^0.2.12"
@@ -49,7 +49,9 @@ maintenance = { status = "passively-maintained" }
 
 [features]
 real_blackbox = []
-default = []
+filter_regex = ["regex"]
+default = ["filter_regex"]
+
 
 [workspace]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ exclude = ["book/*"]
 
 [dependencies]
 lazy_static = "1.4"
-criterion-plot = { path="plot", version="0.4.1" }
-itertools = "0.8"
+criterion-plot = { path="plot", version="0.4.1", optional = true }
+itertools = { version = "0.8", optional = true }
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
@@ -24,9 +24,9 @@ atty = "0.2"
 clap = { version = "2.33", default-features = false }
 csv = "1.1"
 walkdir = "2.3"
-tinytemplate = "1.0"
+tinytemplate = { version = "1.0", optional = true }
 cast = "0.2"
-num-traits = { version = "0.2", default-features = false }
+num-traits = { version = "0.2", default-features = false, features = ["std"] }
 oorandom = "11.1"
 rayon = "1.3"
 regex = { version = "1.3", default-features = false, features = ["std"], optional = true }
@@ -34,7 +34,8 @@ regex = { version = "1.3", default-features = false, features = ["std"], optiona
 [dependencies.plotters]
 version = "^0.2.12"
 default-features = false
-features = ["svg", "area_series", "line_series"] 
+features = ["svg", "area_series", "line_series"]
+optional = true
 
 [dev-dependencies]
 tempdir = "0.3.7"
@@ -50,8 +51,8 @@ maintenance = { status = "passively-maintained" }
 [features]
 real_blackbox = []
 filter_regex = ["regex"]
-default = ["filter_regex"]
-
+plotting = ["criterion-plot", "itertools", "tinytemplate", "plotters"]
+default = ["filter_regex", "plotting"]
 
 [workspace]
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "csv")]
 use csv::Error as CsvError;
 use serde_json::Error as SerdeError;
 use std::error::Error as StdError;
@@ -20,6 +21,7 @@ pub enum Error {
         path: PathBuf,
         inner: SerdeError,
     },
+    #[cfg(feature = "csv")]
     CsvError(CsvError),
 }
 impl fmt::Display for Error {
@@ -36,6 +38,7 @@ impl fmt::Display for Error {
                 "Failed to read or write file {:?} due to serialization error: {}",
                 path, inner
             ),
+            #[cfg(feature = "csv")]
             Error::CsvError(inner) => write!(f, "CSV error: {}", inner),
         }
     }
@@ -46,6 +49,7 @@ impl StdError for Error {
             Error::AccessError { .. } => "AccessError",
             Error::CopyError { .. } => "CopyError",
             Error::SerdeError { .. } => "SerdeError",
+            #[cfg(feature = "csv")]
             Error::CsvError(_) => "CsvError",
         }
     }
@@ -55,10 +59,12 @@ impl StdError for Error {
             Error::AccessError { inner, .. } => Some(inner),
             Error::CopyError { inner, .. } => Some(inner),
             Error::SerdeError { inner, .. } => Some(inner),
+            #[cfg(feature = "csv")]
             Error::CsvError(inner) => Some(inner),
         }
     }
 }
+#[cfg(feature = "csv")]
 impl From<CsvError> for Error {
     fn from(other: CsvError) -> Error {
         Error::CsvError(other)

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,13 +1,16 @@
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use serde_json;
+#[cfg(feature = "plotting")]
 use std::ffi::OsStr;
 use std::fs::{self, File};
 use std::io::Read;
 use std::path::Path;
+#[cfg(feature = "plotting")]
 use walkdir::{DirEntry, WalkDir};
 
 use crate::error::{Error, Result};
+#[cfg(feature = "plotting")]
 use crate::report::BenchmarkId;
 
 pub fn load<A, P: ?Sized>(path: &P) -> Result<A>
@@ -29,7 +32,7 @@ where
 
     Ok(result)
 }
-
+#[cfg(feature = "plotting")]
 pub fn is_dir<P>(path: &P) -> bool
 where
     P: AsRef<Path>,
@@ -86,6 +89,7 @@ where
     Ok(())
 }
 
+#[cfg(feature = "plotting")]
 pub fn list_existing_benchmarks<P>(directory: &P) -> Result<Vec<BenchmarkId>>
 where
     P: AsRef<Path>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,7 @@ mod analysis;
 mod benchmark;
 #[macro_use]
 mod benchmark_group;
+#[cfg(feature = "csv")]
 mod csv_report;
 mod error;
 mod estimate;
@@ -94,6 +95,7 @@ use criterion_plot::{Version, VersionError};
 
 use crate::benchmark::BenchmarkConfig;
 use crate::benchmark::NamedRoutine;
+#[cfg(feature = "csv")]
 use crate::csv_report::FileCsvReport;
 use crate::estimate::{Distributions, Estimates, Statistic};
 #[cfg(feature = "plotting")]
@@ -735,7 +737,10 @@ impl Default for Criterion {
     fn default() -> Criterion {
         let mut reports: Vec<Box<dyn Report>> = vec![];
         reports.push(Box::new(CliReport::new(false, false, false)));
-        reports.push(Box::new(FileCsvReport));
+        #[cfg(feature = "csv")]
+        {
+            reports.push(Box::new(FileCsvReport));
+        }
 
         let output_directory =
             match std::env::vars().find(|&(ref key, _)| key == "CARGO_TARGET_DIR") {
@@ -973,7 +978,10 @@ impl<M: Measurement> Criterion<M> {
         self.plotting_enabled = true;
         let mut reports: Vec<Box<dyn Report>> = vec![];
         reports.push(Box::new(CliReport::new(false, false, false)));
-        reports.push(Box::new(FileCsvReport));
+        #[cfg(feature = "csv")]
+        {
+            reports.push(Box::new(FileCsvReport));
+        }
         #[cfg(feature = "plotting")]
         {
             reports.push(Box::new(Html::new(self.create_plotter())));
@@ -991,7 +999,10 @@ impl<M: Measurement> Criterion<M> {
         }
         let mut reports: Vec<Box<dyn Report>> = vec![];
         reports.push(Box::new(CliReport::new(false, false, false)));
-        reports.push(Box::new(FileCsvReport));
+        #[cfg(feature = "csv")]
+        {
+            reports.push(Box::new(FileCsvReport));
+        }
         self.report = Box::new(Reports::new(reports));
         self
     }
@@ -1237,7 +1248,10 @@ To test that the benchmarks work, run `cargo test --benches`
             enable_text_coloring,
             verbose,
         )));
-        reports.push(Box::new(FileCsvReport));
+        #[cfg(feature = "csv")]
+        {
+            reports.push(Box::new(FileCsvReport));
+        }
 
         if matches.is_present("profile-time") {
             let num_seconds = value_t!(matches.value_of("profile-time"), u64).unwrap_or_else(|e| {

--- a/src/report.rs
+++ b/src/report.rs
@@ -15,6 +15,7 @@ use std::collections::HashSet;
 use std::fmt;
 use std::io::stdout;
 use std::io::Write;
+#[cfg(feature = "plotting")]
 use std::path::{Path, PathBuf};
 
 const MAX_DIRECTORY_NAME_LEN: usize = 64;
@@ -51,7 +52,7 @@ impl<'a> MeasurementData<'a> {
         self.data.y()
     }
 }
-
+#[cfg(feature = "plotting")]
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum ValueType {
     Bytes,
@@ -169,6 +170,7 @@ impl BenchmarkId {
         &self.directory_name
     }
 
+    #[cfg(feature = "plotting")]
     pub fn as_number(&self) -> Option<f64> {
         match self.throughput {
             Some(Throughput::Bytes(n)) | Some(Throughput::Elements(n)) => Some(n as f64),
@@ -179,6 +181,7 @@ impl BenchmarkId {
         }
     }
 
+    #[cfg(feature = "plotting")]
     pub fn value_type(&self) -> Option<ValueType> {
         match self.throughput {
             Some(Throughput::Bytes(_)) => Some(ValueType::Bytes),
@@ -254,6 +257,7 @@ pub struct ReportContext {
     pub test_mode: bool,
 }
 impl ReportContext {
+    #[cfg(feature = "plotting")]
     pub fn report_path<P: AsRef<Path> + ?Sized>(&self, id: &BenchmarkId, file_name: &P) -> PathBuf {
         let mut path = PathBuf::from(format!(
             "{}/{}/report",

--- a/src/report.rs
+++ b/src/report.rs
@@ -5,6 +5,7 @@ use crate::stats::univariate::outliers::tukey::LabeledSample;
 use crate::estimate::{Distributions, Estimates, Statistic};
 use crate::format;
 use crate::measurement::ValueFormatter;
+#[cfg(feature = "csv")]
 use crate::stats::univariate::Sample;
 use crate::stats::Distribution;
 use crate::Estimate;
@@ -43,6 +44,7 @@ pub(crate) struct MeasurementData<'a> {
     pub comparison: Option<ComparisonData>,
     pub throughput: Option<Throughput>,
 }
+#[cfg(feature = "csv")]
 impl<'a> MeasurementData<'a> {
     pub fn iter_counts(&self) -> &Sample<f64> {
         self.data.x()

--- a/src/stats/univariate/mod.rs
+++ b/src/stats/univariate/mod.rs
@@ -5,6 +5,7 @@ mod percentiles;
 mod resamples;
 mod sample;
 
+#[cfg(feature = "plotting")]
 pub mod kde;
 pub mod mixed;
 pub mod outliers;

--- a/tests/criterion_tests.rs
+++ b/tests/criterion_tests.rs
@@ -26,12 +26,19 @@ fn temp_dir() -> TempDir {
 // Configure a Criterion struct to perform really fast benchmarks. This is not
 // recommended for real benchmarking, only for testing.
 fn short_benchmark(dir: &TempDir) -> Criterion {
-    Criterion::default()
+    let crit = Criterion::default()
         .output_directory(dir.path())
         .warm_up_time(Duration::from_millis(250))
         .measurement_time(Duration::from_millis(500))
-        .nresamples(1000)
-        .with_plots()
+        .nresamples(1000);
+    #[cfg(feature = "plotting")]
+    {
+        crit.with_plots()
+    }
+    #[cfg(not(feature = "plotting"))]
+    {
+        crit.without_plots()
+    }
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
Criterion is painful to use in many cases -- bloating the dependency tree so badly that I move benchmarks into another crate excluded from the workspace -- Otherwise just adding a single criterion benchmark expands the dev-dependency tree so much that it's a huge hit to dev ergonomics.

It has many features -- I don't mind these features on their own. I don't think criterion is a bad library, it just has many bad side effects that should be addressed. The use case I'd want to be available is just looking at CLI output, and then if need to dig in, turn on more features and accept the build time, or something.

Anyway I've probably ranted too much to make you want to accept this work. Sorry. Towards the end these patches got pretty sloppy anyway, which is why I stopped... Also I didn't feel like checking if anything other than default-features and no-default-features worked (probably they are slightly broken).

As is it now, it cuts builds on my machine from 27s to 17s for a debug build and 56s to 40s for a release. Next logical step would be removing serde (this code removes a ton of its use), then ideally rayon although it's not quite as bad and might pay for itself in terms of time IDK.

Outputs from full `cargo clean; cargo +nightly build -Z timing` of before/after here: 

https://gist.github.com/thomcc/e1f4bda8bafa4e164483a1b942782a61