### PR TITLE
Replaced tempdir crate with tempfile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ default-features = false
 features = ["svg", "area_series", "line_series"] 
 
 [dev-dependencies]
-tempdir = "0.3.7"
+tempfile = "3.1"
 approx = "0.3"
 quickcheck = { version = "0.9", default-features = false }
 rand = "0.7"

--- a/tests/criterion_tests.rs
+++ b/tests/criterion_tests.rs
@@ -12,7 +12,7 @@ use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::time::{Duration, SystemTime};
-use tempdir::TempDir;
+use tempfile::{tempdir, TempDir};
 use walkdir::WalkDir;
 
 /*
@@ -20,7 +20,7 @@ use walkdir::WalkDir;
  * Criterion.rs. See the benches folder for actual examples.
  */
 fn temp_dir() -> TempDir {
-    TempDir::new("").unwrap()
+    tempdir().unwrap()
 }
 
 // Configure a Criterion struct to perform really fast benchmarks. This is not


### PR DESCRIPTION
RUSTSEC-2018-0017: tempdir: `tempdir` crate has been deprecated; use `tempfile`
instead

See https://github.com/jbreitbart/criterion-perf-events/issues/2