### PR TITLE
Migrate to plotters 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,9 @@ rayon = "1.3"
 regex = { version = "1.3", default-features = false, features = ["std"] }
 
 [dependencies.plotters]
-version = "^0.2.12"
+version = "^0.3.0"
 default-features = false
-features = ["svg", "area_series", "line_series"] 
+features = ["svg_backend", "area_series", "line_series"] 
 
 [dev-dependencies]
 tempfile = "3.1"

--- a/src/plot/plotters_backend/distributions.rs
+++ b/src/plot/plotters_backend/distributions.rs
@@ -69,7 +69,7 @@ fn abs_distribution(
         )
         .set_label_area_size(LabelAreaPosition::Left, (5).percent_width().min(60))
         .set_label_area_size(LabelAreaPosition::Bottom, (5).percent_height().min(40))
-        .build_ranged(x_range, y_range)
+        .build_cartesian_2d(x_range, y_range)
         .unwrap();
 
     chart
@@ -224,7 +224,7 @@ fn rel_distribution(
         )
         .set_label_area_size(LabelAreaPosition::Left, (5).percent_width().min(60))
         .set_label_area_size(LabelAreaPosition::Bottom, (5).percent_height().min(40))
-        .build_ranged(x_min..x_max, y_range.clone())
+        .build_cartesian_2d(x_min..x_max, y_range.clone())
         .unwrap();
 
     chart

--- a/src/plot/plotters_backend/iteration_times.rs
+++ b/src/plot/plotters_backend/iteration_times.rs
@@ -30,14 +30,14 @@ pub(crate) fn iteration_times_figure(
         .margin((5).percent())
         .set_label_area_size(LabelAreaPosition::Left, (5).percent_width().min(60))
         .set_label_area_size(LabelAreaPosition::Bottom, (5).percent_height().min(40))
-        .build_ranged(x_range, y_range)
+        .build_cartesian_2d(x_range, y_range)
         .unwrap();
 
     chart
         .configure_mesh()
         .y_desc(format!("Average Iteration Time ({})", unit))
         .x_label_formatter(&|x| pretty_print_float(*x, true))
-        .line_style_2(&TRANSPARENT)
+        .light_line_style(&TRANSPARENT)
         .draw()
         .unwrap();
 
@@ -97,14 +97,14 @@ pub(crate) fn iteration_times_comparison_figure(
         .margin((5).percent())
         .set_label_area_size(LabelAreaPosition::Left, (5).percent_width().min(60))
         .set_label_area_size(LabelAreaPosition::Bottom, (5).percent_height().min(40))
-        .build_ranged(0.0..max_samples, y_range)
+        .build_cartesian_2d(0.0..max_samples, y_range)
         .unwrap();
 
     chart
         .configure_mesh()
         .y_desc(format!("Average Iteration Time ({})", unit))
         .x_label_formatter(&|x| pretty_print_float(*x, true))
-        .line_style_2(&TRANSPARENT)
+        .light_line_style(&TRANSPARENT)
         .draw()
         .unwrap();
 

--- a/src/plot/plotters_backend/pdf.rs
+++ b/src/plot/plotters_backend/pdf.rs
@@ -50,7 +50,7 @@ pub(crate) fn pdf_comparison_figure(
         .margin((5).percent())
         .set_label_area_size(LabelAreaPosition::Left, (5).percent_width().min(60))
         .set_label_area_size(LabelAreaPosition::Bottom, (5).percent_height().min(40))
-        .build_ranged(x_range, y_range.clone())
+        .build_cartesian_2d(x_range, y_range.clone())
         .unwrap();
 
     chart
@@ -138,7 +138,7 @@ pub(crate) fn pdf_small(
         .margin((5).percent())
         .set_label_area_size(LabelAreaPosition::Left, (5).percent_width().min(60))
         .set_label_area_size(LabelAreaPosition::Bottom, (5).percent_height().min(40))
-        .build_ranged(xs_.min()..xs_.max(), 0.0..y_limit)
+        .build_cartesian_2d(xs_.min()..xs_.max(), 0.0..y_limit)
         .unwrap();
 
     chart
@@ -218,7 +218,7 @@ pub(crate) fn pdf(
         .set_label_area_size(LabelAreaPosition::Left, (5).percent_width().min(60))
         .set_label_area_size(LabelAreaPosition::Right, (5).percent_width().min(60))
         .set_label_area_size(LabelAreaPosition::Bottom, (5).percent_height().min(40))
-        .build_ranged(xs_.min()..xs_.max(), 0.0..max_iters)
+        .build_cartesian_2d(xs_.min()..xs_.max(), 0.0..max_iters)
         .unwrap()
         .set_secondary_coord(xs_.min()..xs_.max(), 0.0..range.end);
 

--- a/src/plot/plotters_backend/regression.rs
+++ b/src/plot/plotters_backend/regression.rs
@@ -53,7 +53,7 @@ pub(crate) fn regression_figure(
         .margin((5).percent())
         .set_label_area_size(LabelAreaPosition::Left, (5).percent_width().min(60))
         .set_label_area_size(LabelAreaPosition::Bottom, (5).percent_height().min(40))
-        .build_ranged(x_range, y_range)
+        .build_cartesian_2d(x_range, y_range)
         .unwrap();
 
     chart
@@ -61,7 +61,7 @@ pub(crate) fn regression_figure(
         .x_desc(x_label)
         .y_desc(format!("Total sample time ({})", unit))
         .x_label_formatter(&|x| pretty_print_float(x * x_scale, true))
-        .line_style_2(&TRANSPARENT)
+        .light_line_style(&TRANSPARENT)
         .draw()
         .unwrap();
 
@@ -179,7 +179,7 @@ pub(crate) fn regression_comparison_figure(
         .margin((5).percent())
         .set_label_area_size(LabelAreaPosition::Left, (5).percent_width().min(60))
         .set_label_area_size(LabelAreaPosition::Bottom, (5).percent_height().min(40))
-        .build_ranged(0.0..max_iters, 0.0..y_max)
+        .build_cartesian_2d(0.0..max_iters, 0.0..y_max)
         .unwrap();
 
     chart
@@ -187,7 +187,7 @@ pub(crate) fn regression_comparison_figure(
         .x_desc(x_label)
         .y_desc(format!("Total sample time ({})", unit))
         .x_label_formatter(&|x| pretty_print_float(x * x_scale, true))
-        .line_style_2(&TRANSPARENT)
+        .light_line_style(&TRANSPARENT)
         .draw()
         .unwrap();
 

--- a/src/plot/plotters_backend/summary.rs
+++ b/src/plot/plotters_backend/summary.rs
@@ -1,7 +1,10 @@
 use super::*;
 use crate::AxisScale;
 use itertools::Itertools;
-use plotters::coord::{AsRangedCoord, Shift};
+use plotters::coord::{
+    ranged1d::{AsRangedCoord, ValueFormatter as PlottersValueFormatter},
+    Shift,
+};
 use std::cmp::Ordering;
 use std::path::Path;
 
@@ -58,7 +61,10 @@ fn draw_line_comarision_figure<XR: AsRangedCoord<Value = f64>, YR: AsRangedCoord
     y_range: YR,
     value_type: ValueType,
     data: Vec<(Option<&String>, Vec<f64>, Vec<f64>)>,
-) {
+) where
+    XR::CoordDescType: PlottersValueFormatter<f64>,
+    YR::CoordDescType: PlottersValueFormatter<f64>,
+{
     let input_suffix = match value_type {
         ValueType::Bytes => " Size (Bytes)",
         ValueType::Elements => " Size (Elements)",
@@ -69,7 +75,7 @@ fn draw_line_comarision_figure<XR: AsRangedCoord<Value = f64>, YR: AsRangedCoord
         .margin((5).percent())
         .set_label_area_size(LabelAreaPosition::Left, (5).percent_width().min(60))
         .set_label_area_size(LabelAreaPosition::Bottom, (5).percent_height().min(40))
-        .build_ranged(x_range, y_range)
+        .build_cartesian_2d(x_range, y_range)
         .unwrap();
 
     chart
@@ -215,12 +221,15 @@ fn draw_violin_figure<XR: AsRangedCoord<Value = f64>, YR: AsRangedCoord<Value = 
     x_range: XR,
     y_range: YR,
     data: Vec<(&str, Box<[f64]>, Box<[f64]>)>,
-) {
+) where
+    XR::CoordDescType: PlottersValueFormatter<f64>,
+    YR::CoordDescType: PlottersValueFormatter<f64>,
+{
     let mut chart = ChartBuilder::on(&root_area)
         .margin((5).percent())
         .set_label_area_size(LabelAreaPosition::Left, (10).percent_width().min(60))
         .set_label_area_size(LabelAreaPosition::Bottom, (5).percent_width().min(40))
-        .build_ranged(x_range, y_range)
+        .build_cartesian_2d(x_range, y_range)
         .unwrap();
 
     chart

--- a/src/plot/plotters_backend/t_test.rs
+++ b/src/plot/plotters_backend/t_test.rs
@@ -23,7 +23,7 @@ pub(crate) fn t_test(
         .caption(format!("{}: Welch t test", title), (DEFAULT_FONT, 20))
         .set_label_area_size(LabelAreaPosition::Left, (5).percent_width().min(60))
         .set_label_area_size(LabelAreaPosition::Bottom, (5).percent_height().min(40))
-        .build_ranged(x_range, y_range.clone())
+        .build_cartesian_2d(x_range, y_range.clone())
         .unwrap();
 
     chart


### PR DESCRIPTION
Hi there,

I am just published Plotters 0.3 and in the future I would like to focus on maintaining the Plotters 0.3. So I would like make criterion depends on a 0.3 version of Plotters which will be actively maintained. 

Plotters 0.3 has some breaking changes compare to Plotters 0.2, this PR just made those changes. I am just tried Criterion with Plotters 0.3, it works well for me.

For the compile time, the new Plotters v0.3 seems fine (Plotters 0.3 cost ~3s to compile). 

Thanks!

- Hao
