### PR TITLE
Update itertools to 0.10 in criterion-plot

### DIFF
--- a/plot/Cargo.toml
+++ b/plot/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 cast = "0.2"
-itertools = "0.9"
+itertools = "0.10"
 
 [dev-dependencies]
 itertools-num = "0.1"


### PR DESCRIPTION
The main criterion crate currently depends on itertools 0.10 while criterion-plot depends on itertools 0.9 causing duplicated itertools dependencies.