### PR TITLE
Upgrade Plotters to v0.3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ tokio = { version = "1.0", default-features = false, features = ["rt"], optional
 async-std = { version = "1.9", optional = true }
 
 [dependencies.plotters]
-version = "^0.3.0"
+version = "^0.3.1"
 default-features = false
 features = ["svg_backend", "area_series", "line_series"] 
 

--- a/src/plot/plotters_backend/summary.rs
+++ b/src/plot/plotters_backend/summary.rs
@@ -46,8 +46,8 @@ pub fn line_comparison(
         AxisScale::Logarithmic => draw_line_comarision_figure(
             root_area,
             unit,
-            LogRange(x_range),
-            LogRange(y_range),
+            x_range.log_scale(),
+            y_range.log_scale(),
             value_type,
             series_data,
         ),
@@ -211,7 +211,7 @@ pub fn violin(
     match axis_scale {
         AxisScale::Linear => draw_violin_figure(root_area, unit, x_range, y_range, kdes),
         AxisScale::Logarithmic => {
-            draw_violin_figure(root_area, unit, LogRange(x_range), y_range, kdes)
+            draw_violin_figure(root_area, unit, x_range.log_scale(), y_range, kdes)
         }
     }
 }


### PR DESCRIPTION
Upgrade Plotters to v0.3.1, which including the fix for infinite loop bug with the zero-length axis is passed in.  This should address issue #467.