### PR TITLE
Allow calling `criterion::criterion_group` by path

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -73,7 +73,7 @@ macro_rules! criterion_group {
         }
     };
     ($name:ident, $( $target:path ),+ $(,)*) => {
-        criterion_group!{
+        $crate::criterion_group!{
             name = $name;
             config = $crate::Criterion::default();
             targets = $( $target ),+


### PR DESCRIPTION
This is the same as 84d01a55da53b4999bf3c82e10d5c04d935607ce.