### PR TITLE
Basic support for targeting wasm32-wasi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ tinytemplate   = "1.1"
 cast           = "0.2"
 num-traits     = { version = "0.2", default-features = false, features = ["std"] }
 oorandom       = "11.1"
-rayon          = "1.3"
+rayon          = { version = "1.3", optional = true }
 regex          = { version = "1.3", default-features = false, features = ["std"] }
 
 # Optional dependencies
@@ -66,7 +66,7 @@ stable  = [
   "async_tokio",
   "async_std",
 ]
-default = ["plotters", "cargo_bench_support"]
+default = ["rayon", "plotters", "cargo_bench_support"]
 
 # Enable use of the nightly-only test::black_box function to discourage compiler optimizations.
 real_blackbox = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,10 @@ tinytemplate   = "1.1"
 cast           = "0.2"
 num-traits     = { version = "0.2", default-features = false, features = ["std"] }
 oorandom       = "11.1"
-rayon          = { version = "1.3", optional = true }
 regex          = { version = "1.3", default-features = false, features = ["std"] }
 
 # Optional dependencies
+rayon     = { version = "1.3", optional = true }
 csv       = { version = "1.1", optional = true }
 futures   = { version = "0.3", default_features = false, optional = true }
 smol      = { version = "1.2", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ stable  = [
   "async_tokio",
   "async_std",
 ]
-default = ["cargo_bench_support"]
+default = ["plotters", "cargo_bench_support"]
 
 # Enable use of the nightly-only test::black_box function to discourage compiler optimizations.
 real_blackbox = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ clap           = { version = "2.33", default-features = false }
 walkdir        = "2.3"
 tinytemplate   = "1.1"
 cast           = "0.2"
-num-traits     = { version = "0.2", default-features = false }
+num-traits     = { version = "0.2", default-features = false, features = ["std"] }
 oorandom       = "11.1"
 rayon          = "1.3"
 regex          = { version = "1.3", default-features = false, features = ["std"] }
@@ -43,6 +43,7 @@ async-std = { version = "1.9", optional = true }
 
 [dependencies.plotters]
 version          = "^0.3.1"
+optional         = true
 default-features = false
 features         = ["svg_backend", "area_series", "line_series"]
 

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -129,24 +129,28 @@ pub(crate) fn common<M: Measurement, T: ?Sized>(
     let avg_times = Sample::new(&avg_times);
 
     if criterion.connection.is_none() && criterion.load_baseline.is_none() {
-        log_if_err!({
-            let mut new_dir = criterion.output_directory.clone();
-            new_dir.push(id.as_directory_name());
-            new_dir.push("new");
-            fs::mkdirp(&new_dir)
-        });
+        if !matches!(criterion.baseline, Baseline::Discard) {
+            log_if_err!({
+                let mut new_dir = criterion.output_directory.clone();
+                new_dir.push(id.as_directory_name());
+                new_dir.push("new");
+                fs::mkdirp(&new_dir)
+            });
+        }
     }
 
     let data = Data::new(&iters, &times);
     let labeled_sample = tukey::classify(avg_times);
     if criterion.connection.is_none() {
-        log_if_err!({
-            let mut tukey_file = criterion.output_directory.to_owned();
-            tukey_file.push(id.as_directory_name());
-            tukey_file.push("new");
-            tukey_file.push("tukey.json");
-            fs::save(&labeled_sample.fences(), &tukey_file)
-        });
+        if !matches!(criterion.baseline, Baseline::Discard) {
+            log_if_err!({
+                let mut tukey_file = criterion.output_directory.to_owned();
+                tukey_file.push(id.as_directory_name());
+                tukey_file.push("new");
+                tukey_file.push("tukey.json");
+                fs::save(&labeled_sample.fences(), &tukey_file)
+            });
+        }
     }
     let (mut distributions, mut estimates) = estimates(avg_times, config);
     if sampling_mode.is_linear() {
@@ -157,27 +161,29 @@ pub(crate) fn common<M: Measurement, T: ?Sized>(
     }
 
     if criterion.connection.is_none() && criterion.load_baseline.is_none() {
-        log_if_err!({
-            let mut sample_file = criterion.output_directory.clone();
-            sample_file.push(id.as_directory_name());
-            sample_file.push("new");
-            sample_file.push("sample.json");
-            fs::save(
-                &SavedSample {
-                    sampling_mode,
-                    iters: data.x().as_ref().to_vec(),
-                    times: data.y().as_ref().to_vec(),
-                },
-                &sample_file,
-            )
-        });
-        log_if_err!({
-            let mut estimates_file = criterion.output_directory.clone();
-            estimates_file.push(id.as_directory_name());
-            estimates_file.push("new");
-            estimates_file.push("estimates.json");
-            fs::save(&estimates, &estimates_file)
-        });
+        if !matches!(criterion.baseline, Baseline::Discard) {
+            log_if_err!({
+                let mut sample_file = criterion.output_directory.clone();
+                sample_file.push(id.as_directory_name());
+                sample_file.push("new");
+                sample_file.push("sample.json");
+                fs::save(
+                    &SavedSample {
+                        sampling_mode,
+                        iters: data.x().as_ref().to_vec(),
+                        times: data.y().as_ref().to_vec(),
+                    },
+                    &sample_file,
+                )
+            });
+            log_if_err!({
+                let mut estimates_file = criterion.output_directory.clone();
+                estimates_file.push(id.as_directory_name());
+                estimates_file.push("new");
+                estimates_file.push("estimates.json");
+                fs::save(&estimates, &estimates_file)
+            });
+        }
     }
 
     let compare_data = if base_dir_exists(
@@ -238,13 +244,15 @@ pub(crate) fn common<M: Measurement, T: ?Sized>(
     );
 
     if criterion.connection.is_none() && criterion.load_baseline.is_none() {
-        log_if_err!({
-            let mut benchmark_file = criterion.output_directory.clone();
-            benchmark_file.push(id.as_directory_name());
-            benchmark_file.push("new");
-            benchmark_file.push("benchmark.json");
-            fs::save(&id, &benchmark_file)
-        });
+        if !matches!(criterion.baseline, Baseline::Discard) {
+            log_if_err!({
+                let mut benchmark_file = criterion.output_directory.clone();
+                benchmark_file.push(id.as_directory_name());
+                benchmark_file.push("new");
+                benchmark_file.push("benchmark.json");
+                fs::save(&id, &benchmark_file)
+            });
+        }
     }
 
     if criterion.connection.is_none() {

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -128,29 +128,28 @@ pub(crate) fn common<M: Measurement, T: ?Sized>(
         .collect::<Vec<f64>>();
     let avg_times = Sample::new(&avg_times);
 
-    if criterion.connection.is_none() && criterion.load_baseline.is_none() {
-        if !matches!(criterion.baseline, Baseline::Discard) {
-            log_if_err!({
-                let mut new_dir = criterion.output_directory.clone();
-                new_dir.push(id.as_directory_name());
-                new_dir.push("new");
-                fs::mkdirp(&new_dir)
-            });
-        }
+    if criterion.connection.is_none()
+        && criterion.load_baseline.is_none()
+        && !matches!(criterion.baseline, Baseline::Discard)
+    {
+        log_if_err!({
+            let mut new_dir = criterion.output_directory.clone();
+            new_dir.push(id.as_directory_name());
+            new_dir.push("new");
+            fs::mkdirp(&new_dir)
+        });
     }
 
     let data = Data::new(&iters, &times);
     let labeled_sample = tukey::classify(avg_times);
-    if criterion.connection.is_none() {
-        if !matches!(criterion.baseline, Baseline::Discard) {
-            log_if_err!({
-                let mut tukey_file = criterion.output_directory.to_owned();
-                tukey_file.push(id.as_directory_name());
-                tukey_file.push("new");
-                tukey_file.push("tukey.json");
-                fs::save(&labeled_sample.fences(), &tukey_file)
-            });
-        }
+    if criterion.connection.is_none() && !matches!(criterion.baseline, Baseline::Discard) {
+        log_if_err!({
+            let mut tukey_file = criterion.output_directory.to_owned();
+            tukey_file.push(id.as_directory_name());
+            tukey_file.push("new");
+            tukey_file.push("tukey.json");
+            fs::save(&labeled_sample.fences(), &tukey_file)
+        });
     }
     let (mut distributions, mut estimates) = estimates(avg_times, config);
     if sampling_mode.is_linear() {
@@ -160,30 +159,31 @@ pub(crate) fn common<M: Measurement, T: ?Sized>(
         distributions.slope = Some(distribution);
     }
 
-    if criterion.connection.is_none() && criterion.load_baseline.is_none() {
-        if !matches!(criterion.baseline, Baseline::Discard) {
-            log_if_err!({
-                let mut sample_file = criterion.output_directory.clone();
-                sample_file.push(id.as_directory_name());
-                sample_file.push("new");
-                sample_file.push("sample.json");
-                fs::save(
-                    &SavedSample {
-                        sampling_mode,
-                        iters: data.x().as_ref().to_vec(),
-                        times: data.y().as_ref().to_vec(),
-                    },
-                    &sample_file,
-                )
-            });
-            log_if_err!({
-                let mut estimates_file = criterion.output_directory.clone();
-                estimates_file.push(id.as_directory_name());
-                estimates_file.push("new");
-                estimates_file.push("estimates.json");
-                fs::save(&estimates, &estimates_file)
-            });
-        }
+    if criterion.connection.is_none()
+        && criterion.load_baseline.is_none()
+        && !matches!(criterion.baseline, Baseline::Discard)
+    {
+        log_if_err!({
+            let mut sample_file = criterion.output_directory.clone();
+            sample_file.push(id.as_directory_name());
+            sample_file.push("new");
+            sample_file.push("sample.json");
+            fs::save(
+                &SavedSample {
+                    sampling_mode,
+                    iters: data.x().as_ref().to_vec(),
+                    times: data.y().as_ref().to_vec(),
+                },
+                &sample_file,
+            )
+        });
+        log_if_err!({
+            let mut estimates_file = criterion.output_directory.clone();
+            estimates_file.push(id.as_directory_name());
+            estimates_file.push("new");
+            estimates_file.push("estimates.json");
+            fs::save(&estimates, &estimates_file)
+        });
     }
 
     let compare_data = if base_dir_exists(
@@ -243,16 +243,17 @@ pub(crate) fn common<M: Measurement, T: ?Sized>(
         criterion.measurement.formatter(),
     );
 
-    if criterion.connection.is_none() && criterion.load_baseline.is_none() {
-        if !matches!(criterion.baseline, Baseline::Discard) {
-            log_if_err!({
-                let mut benchmark_file = criterion.output_directory.clone();
-                benchmark_file.push(id.as_directory_name());
-                benchmark_file.push("new");
-                benchmark_file.push("benchmark.json");
-                fs::save(&id, &benchmark_file)
-            });
-        }
+    if criterion.connection.is_none()
+        && criterion.load_baseline.is_none()
+        && !matches!(criterion.baseline, Baseline::Discard)
+    {
+        log_if_err!({
+            let mut benchmark_file = criterion.output_directory.clone();
+            benchmark_file.push(id.as_directory_name());
+            benchmark_file.push("new");
+            benchmark_file.push("benchmark.json");
+            fs::save(&id, &benchmark_file)
+        });
     }
 
     if criterion.connection.is_none() {

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -128,10 +128,7 @@ pub(crate) fn common<M: Measurement, T: ?Sized>(
         .collect::<Vec<f64>>();
     let avg_times = Sample::new(&avg_times);
 
-    if criterion.connection.is_none()
-        && criterion.load_baseline.is_none()
-        && !matches!(criterion.baseline, Baseline::Discard)
-    {
+    if criterion.should_save_baseline() {
         log_if_err!({
             let mut new_dir = criterion.output_directory.clone();
             new_dir.push(id.as_directory_name());
@@ -142,7 +139,7 @@ pub(crate) fn common<M: Measurement, T: ?Sized>(
 
     let data = Data::new(&iters, &times);
     let labeled_sample = tukey::classify(avg_times);
-    if criterion.connection.is_none() && !matches!(criterion.baseline, Baseline::Discard) {
+    if criterion.should_save_baseline() {
         log_if_err!({
             let mut tukey_file = criterion.output_directory.to_owned();
             tukey_file.push(id.as_directory_name());
@@ -159,10 +156,7 @@ pub(crate) fn common<M: Measurement, T: ?Sized>(
         distributions.slope = Some(distribution);
     }
 
-    if criterion.connection.is_none()
-        && criterion.load_baseline.is_none()
-        && !matches!(criterion.baseline, Baseline::Discard)
-    {
+    if criterion.should_save_baseline() {
         log_if_err!({
             let mut sample_file = criterion.output_directory.clone();
             sample_file.push(id.as_directory_name());
@@ -243,10 +237,7 @@ pub(crate) fn common<M: Measurement, T: ?Sized>(
         criterion.measurement.formatter(),
     );
 
-    if criterion.connection.is_none()
-        && criterion.load_baseline.is_none()
-        && !matches!(criterion.baseline, Baseline::Discard)
-    {
+    if criterion.should_save_baseline() {
         log_if_err!({
             let mut benchmark_file = criterion.output_directory.clone();
             benchmark_file.push(id.as_directory_name());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,6 +271,8 @@ pub enum Baseline {
     /// Save writes the benchmark results to the baseline directory,
     /// overwriting any results that were previously there.
     Save,
+    /// Discard benchmark results.
+    Discard,
 }
 
 /// Enum used to select the plotting backend.
@@ -719,6 +721,9 @@ impl<M: Measurement> Criterion<M> {
                 .long("save-baseline")
                 .default_value("base")
                 .help("Save results under a named baseline."))
+            .arg(Arg::with_name("discard-baseline")
+                .long("discard-baseline")
+                .help("Save results under a named baseline."))
             .arg(Arg::with_name("baseline")
                 .short("b")
                 .long("baseline")
@@ -897,6 +902,9 @@ https://bheisler.github.io/criterion.rs/book/faq.html
         if let Some(dir) = matches.value_of("save-baseline") {
             self.baseline = Baseline::Save;
             self.baseline_directory = dir.to_owned()
+        }
+        if matches.is_present("discard-baseline") {
+            self.baseline = Baseline::Discard;
         }
         if let Some(dir) = matches.value_of("baseline") {
             self.baseline = Baseline::Compare;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -723,7 +723,8 @@ impl<M: Measurement> Criterion<M> {
                 .help("Save results under a named baseline."))
             .arg(Arg::with_name("discard-baseline")
                 .long("discard-baseline")
-                .help("Save results under a named baseline."))
+                .conflicts_with_all(&["save-baseline", "baseline"])
+                .help("Discard benchmark results."))
             .arg(Arg::with_name("baseline")
                 .short("b")
                 .long("baseline")
@@ -1033,6 +1034,14 @@ https://bheisler.github.io/criterion.rs/book/faq.html
             Some(ref regex) => regex.is_match(id),
             None => true,
         }
+    }
+
+    /// Returns true iff we should save the benchmark results in
+    /// json files on the local disk.
+    fn should_save_baseline(&self) -> bool {
+        self.connection.is_none()
+            && self.load_baseline.is_none()
+            && !matches!(self.baseline, Baseline::Discard)
     }
 
     /// Return a benchmark group. All benchmarks performed using a benchmark group will be

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,9 @@ use crate::connection::Connection;
 use crate::connection::OutgoingMessage;
 use crate::html::Html;
 use crate::measurement::{Measurement, WallTime};
-use crate::plot::{Gnuplot, Plotter, PlottersBackend};
+#[cfg(feature = "plotters")]
+use crate::plot::PlottersBackend;
+use crate::plot::{Gnuplot, Plotter};
 use crate::profiler::{ExternalProfiler, Profiler};
 use crate::report::{BencherReport, CliReport, Report, ReportContext, Reports};
 
@@ -281,7 +283,10 @@ impl PlottingBackend {
     fn create_plotter(&self) -> Box<dyn Plotter> {
         match self {
             PlottingBackend::Gnuplot => Box::new(Gnuplot::default()),
+            #[cfg(feature = "plotters")]
             PlottingBackend::Plotters => Box::new(PlottersBackend::default()),
+            #[cfg(not(feature = "plotters"))]
+            PlottingBackend::Plotters => panic!("Criterion was built without plotters support."),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,12 +105,10 @@ lazy_static! {
     static ref DEBUG_ENABLED: bool = std::env::var_os("CRITERION_DEBUG").is_some();
     static ref GNUPLOT_VERSION: Result<Version, VersionError> = criterion_plot::version();
     static ref DEFAULT_PLOTTING_BACKEND: PlottingBackend = {
-        match &*GNUPLOT_VERSION {
-            Ok(_) => PlottingBackend::Gnuplot,
-            Err(e) => {
-                if cfg!(not(feature = "plotters")) {
-                    PlottingBackend::None
-                } else {
+        if cfg!(feature = "html_reports") {
+            match &*GNUPLOT_VERSION {
+                Ok(_) => PlottingBackend::Gnuplot,
+                Err(e) => {
                     match e {
                         VersionError::Exec(_) => eprintln!("Gnuplot not found, using plotters backend"),
                         e => eprintln!(
@@ -121,6 +119,8 @@ lazy_static! {
                     PlottingBackend::Plotters
                 }
             }
+        } else {
+            PlottingBackend::None
         }
     };
     static ref CARGO_CRITERION_CONNECTION: Option<Mutex<Connection>> = {
@@ -895,8 +895,6 @@ https://bheisler.github.io/criterion.rs/book/faq.html
 
         if matches.is_present("noplot") {
             self = self.without_plots();
-        } else {
-            self = self.with_plots();
         }
 
         if let Some(dir) = matches.value_of("save-baseline") {

--- a/src/plot/mod.rs
+++ b/src/plot/mod.rs
@@ -1,7 +1,9 @@
 mod gnuplot_backend;
+#[cfg(feature = "plotters")]
 mod plotters_backend;
 
 pub(crate) use gnuplot_backend::Gnuplot;
+#[cfg(feature = "plotters")]
 pub(crate) use plotters_backend::PlottersBackend;
 
 use crate::estimate::Statistic;

--- a/src/plot/mod.rs
+++ b/src/plot/mod.rs
@@ -103,3 +103,39 @@ pub(crate) trait Plotter {
 
     fn wait(&mut self);
 }
+
+#[derive(Default)]
+pub(crate) struct NullPlotter;
+
+impl Plotter for NullPlotter {
+    fn pdf(&mut self, _ctx: PlotContext<'_>, _data: PlotData<'_>) {}
+
+    fn regression(&mut self, _ctx: PlotContext<'_>, _data: PlotData<'_>) {}
+
+    fn iteration_times(&mut self, _ctx: PlotContext<'_>, _data: PlotData<'_>) {}
+
+    fn abs_distributions(&mut self, _ctx: PlotContext<'_>, _data: PlotData<'_>) {}
+
+    fn rel_distributions(&mut self, _ctx: PlotContext<'_>, _data: PlotData<'_>) {}
+
+    fn line_comparison(
+        &mut self,
+        _ctx: PlotContext<'_>,
+        _formatter: &dyn ValueFormatter,
+        _all_curves: &[&(&BenchmarkId, Vec<f64>)],
+        _value_type: ValueType,
+    ) {
+    }
+
+    fn violin(
+        &mut self,
+        _ctx: PlotContext<'_>,
+        _formatter: &dyn ValueFormatter,
+        _all_curves: &[&(&BenchmarkId, Vec<f64>)],
+    ) {
+    }
+
+    fn t_test(&mut self, _ctx: PlotContext<'_>, _data: PlotData<'_>) {}
+
+    fn wait(&mut self) {}
+}

--- a/src/plot/mod.rs
+++ b/src/plot/mod.rs
@@ -103,39 +103,3 @@ pub(crate) trait Plotter {
 
     fn wait(&mut self);
 }
-
-#[derive(Default)]
-pub(crate) struct NullPlotter;
-
-impl Plotter for NullPlotter {
-    fn pdf(&mut self, _ctx: PlotContext<'_>, _data: PlotData<'_>) {}
-
-    fn regression(&mut self, _ctx: PlotContext<'_>, _data: PlotData<'_>) {}
-
-    fn iteration_times(&mut self, _ctx: PlotContext<'_>, _data: PlotData<'_>) {}
-
-    fn abs_distributions(&mut self, _ctx: PlotContext<'_>, _data: PlotData<'_>) {}
-
-    fn rel_distributions(&mut self, _ctx: PlotContext<'_>, _data: PlotData<'_>) {}
-
-    fn line_comparison(
-        &mut self,
-        _ctx: PlotContext<'_>,
-        _formatter: &dyn ValueFormatter,
-        _all_curves: &[&(&BenchmarkId, Vec<f64>)],
-        _value_type: ValueType,
-    ) {
-    }
-
-    fn violin(
-        &mut self,
-        _ctx: PlotContext<'_>,
-        _formatter: &dyn ValueFormatter,
-        _all_curves: &[&(&BenchmarkId, Vec<f64>)],
-    ) {
-    }
-
-    fn t_test(&mut self, _ctx: PlotContext<'_>, _data: PlotData<'_>) {}
-
-    fn wait(&mut self) {}
-}

--- a/src/report.rs
+++ b/src/report.rs
@@ -307,8 +307,7 @@ pub(crate) struct Reports {
     pub(crate) bencher_enabled: bool,
     pub(crate) bencher: BencherReport,
     pub(crate) csv_enabled: bool,
-    pub(crate) html_enabled: bool,
-    pub(crate) html: Html,
+    pub(crate) html: Option<Html>,
 }
 macro_rules! reports_impl {
     (fn $name:ident(&self, $($argn:ident: $argt:ty),*)) => {
@@ -323,8 +322,8 @@ macro_rules! reports_impl {
             if self.csv_enabled {
                 FileCsvReport.$name($($argn),*);
             }
-            if self.html_enabled {
-                self.html.$name($($argn),*);
+            if let Some(reporter) = &self.html {
+                reporter.$name($($argn),*);
             }
         }
     };

--- a/src/stats/univariate/kde/mod.rs
+++ b/src/stats/univariate/kde/mod.rs
@@ -44,19 +44,14 @@ where
     /// - Multihreaded
     pub fn map(&self, xs: &[A]) -> Box<[A]> {
         #[cfg(feature = "rayon")]
-        {
-            xs.par_iter()
-                .map(|&x| self.estimate(x))
-                .collect::<Vec<_>>()
-                .into_boxed_slice()
-        }
+        let iter = xs.par_iter();
+
         #[cfg(not(feature = "rayon"))]
-        {
-            xs.iter()
-                .map(|&x| self.estimate(x))
-                .collect::<Vec<_>>()
-                .into_boxed_slice()
-        }
+        let iter = xs.iter();
+
+        iter.map(|&x| self.estimate(x))
+            .collect::<Vec<_>>()
+            .into_boxed_slice()
     }
 
     /// Estimates the probability density of `x`

--- a/src/stats/univariate/kde/mod.rs
+++ b/src/stats/univariate/kde/mod.rs
@@ -5,6 +5,7 @@ pub mod kernel;
 use self::kernel::Kernel;
 use crate::stats::float::Float;
 use crate::stats::univariate::Sample;
+#[cfg(feature = "rayon")]
 use rayon::prelude::*;
 
 /// Univariate kernel density estimator
@@ -42,10 +43,20 @@ where
     ///
     /// - Multihreaded
     pub fn map(&self, xs: &[A]) -> Box<[A]> {
-        xs.par_iter()
-            .map(|&x| self.estimate(x))
-            .collect::<Vec<_>>()
-            .into_boxed_slice()
+        #[cfg(feature = "rayon")]
+        {
+            xs.par_iter()
+                .map(|&x| self.estimate(x))
+                .collect::<Vec<_>>()
+                .into_boxed_slice()
+        }
+        #[cfg(not(feature = "rayon"))]
+        {
+            xs.iter()
+                .map(|&x| self.estimate(x))
+                .collect::<Vec<_>>()
+                .into_boxed_slice()
+        }
     }
 
     /// Estimates the probability density of `x`

--- a/src/stats/univariate/sample.rs
+++ b/src/stats/univariate/sample.rs
@@ -4,6 +4,7 @@ use crate::stats::float::Float;
 use crate::stats::tuple::{Tuple, TupledDistributionsBuilder};
 use crate::stats::univariate::Percentiles;
 use crate::stats::univariate::Resamples;
+#[cfg(feature = "rayon")]
 use rayon::prelude::*;
 
 /// A collection of data points drawn from a population
@@ -127,7 +128,10 @@ where
         }
 
         let mut v = self.to_vec().into_boxed_slice();
+        #[cfg(feature = "rayon")]
         v.par_sort_unstable_by(cmp);
+        #[cfg(not(feature = "rayon"))]
+        v.sort_unstable_by(cmp);
 
         // NB :-1: to intra-crate privacy rules
         unsafe { mem::transmute(v) }
@@ -206,27 +210,41 @@ where
         T::Distributions: Send,
         T::Builder: Send,
     {
-        (0..nresamples)
-            .into_par_iter()
-            .map_init(
-                || Resamples::new(self),
-                |resamples, _| statistic(resamples.next()),
-            )
-            .fold(
-                || T::Builder::new(0),
-                |mut sub_distributions, sample| {
+        #[cfg(feature = "rayon")]
+        {
+            (0..nresamples)
+                .into_par_iter()
+                .map_init(
+                    || Resamples::new(self),
+                    |resamples, _| statistic(resamples.next()),
+                )
+                .fold(
+                    || T::Builder::new(0),
+                    |mut sub_distributions, sample| {
+                        sub_distributions.push(sample);
+                        sub_distributions
+                    },
+                )
+                .reduce(
+                    || T::Builder::new(0),
+                    |mut a, mut b| {
+                        a.extend(&mut b);
+                        a
+                    },
+                )
+                .complete()
+        }
+        #[cfg(not(feature = "rayon"))]
+        {
+            let mut resamples = Resamples::new(self);
+            (0..nresamples)
+                .map(|_| statistic(resamples.next()))
+                .fold(T::Builder::new(0), |mut sub_distributions, sample| {
                     sub_distributions.push(sample);
                     sub_distributions
-                },
-            )
-            .reduce(
-                || T::Builder::new(0),
-                |mut a, mut b| {
-                    a.extend(&mut b);
-                    a
-                },
-            )
-            .complete()
+                })
+                .complete()
+        }
     }
 
     #[cfg(test)]

--- a/tests/criterion_tests.rs
+++ b/tests/criterion_tests.rs
@@ -310,6 +310,7 @@ fn test_timing_loops() {
 }
 
 // Verify that all expected output files are present
+#[cfg(feature = "plotters")]
 #[test]
 fn test_output_files() {
     let tempdir = temp_dir();
@@ -370,6 +371,7 @@ fn test_output_files() {
     verify_html(&dir, "report/index.html");
 }
 
+#[cfg(feature = "plotters")]
 #[test]
 fn test_output_files_flat_sampling() {
     let tempdir = temp_dir();

--- a/tests/criterion_tests.rs
+++ b/tests/criterion_tests.rs
@@ -31,7 +31,6 @@ fn short_benchmark(dir: &TempDir) -> Criterion {
         .warm_up_time(Duration::from_millis(250))
         .measurement_time(Duration::from_millis(500))
         .nresamples(2000)
-        .with_plots()
 }
 
 #[derive(Clone)]
@@ -73,10 +72,12 @@ fn verify_json(dir: &PathBuf, path: &str) {
     serde_json::from_reader::<File, Value>(f).unwrap();
 }
 
+#[cfg(feature = "html_reports")]
 fn verify_svg(dir: &PathBuf, path: &str) {
     verify_file(dir, path);
 }
 
+#[cfg(feature = "html_reports")]
 fn verify_html(dir: &PathBuf, path: &str) {
     verify_file(dir, path);
 }
@@ -337,38 +338,47 @@ fn test_output_files() {
         verify_stats(&dir, "base");
         verify_json(&dir, "change/estimates.json");
 
-        verify_svg(&dir, "report/MAD.svg");
-        verify_svg(&dir, "report/mean.svg");
-        verify_svg(&dir, "report/median.svg");
-        verify_svg(&dir, "report/pdf.svg");
-        verify_svg(&dir, "report/regression.svg");
-        verify_svg(&dir, "report/SD.svg");
-        verify_svg(&dir, "report/slope.svg");
-        verify_svg(&dir, "report/typical.svg");
-        verify_svg(&dir, "report/both/pdf.svg");
-        verify_svg(&dir, "report/both/regression.svg");
-        verify_svg(&dir, "report/change/mean.svg");
-        verify_svg(&dir, "report/change/median.svg");
-        verify_svg(&dir, "report/change/t-test.svg");
+        #[cfg(feature = "html_reports")]
+        {
+            verify_svg(&dir, "report/MAD.svg");
+            verify_svg(&dir, "report/mean.svg");
+            verify_svg(&dir, "report/median.svg");
+            verify_svg(&dir, "report/pdf.svg");
+            verify_svg(&dir, "report/regression.svg");
+            verify_svg(&dir, "report/SD.svg");
+            verify_svg(&dir, "report/slope.svg");
+            verify_svg(&dir, "report/typical.svg");
+            verify_svg(&dir, "report/both/pdf.svg");
+            verify_svg(&dir, "report/both/regression.svg");
+            verify_svg(&dir, "report/change/mean.svg");
+            verify_svg(&dir, "report/change/median.svg");
+            verify_svg(&dir, "report/change/t-test.svg");
 
-        verify_svg(&dir, "report/pdf_small.svg");
-        verify_svg(&dir, "report/regression_small.svg");
-        verify_svg(&dir, "report/relative_pdf_small.svg");
-        verify_svg(&dir, "report/relative_regression_small.svg");
+            verify_svg(&dir, "report/pdf_small.svg");
+            verify_svg(&dir, "report/regression_small.svg");
+            verify_svg(&dir, "report/relative_pdf_small.svg");
+            verify_svg(&dir, "report/relative_regression_small.svg");
+            verify_html(&dir, "report/index.html");
+        }
+    }
+
+    #[cfg(feature = "html_reports")]
+    {
+        // Check for overall report files
+        let dir = tempdir.path().join("test_output");
+
+        verify_svg(&dir, "report/violin.svg");
         verify_html(&dir, "report/index.html");
     }
 
-    // Check for overall report files
-    let dir = tempdir.path().join("test_output");
-
-    verify_svg(&dir, "report/violin.svg");
-    verify_html(&dir, "report/index.html");
-
     // Run the final summary process and check for the report that produces
     short_benchmark(&tempdir).final_summary();
-    let dir = tempdir.path().to_owned();
 
-    verify_html(&dir, "report/index.html");
+    #[cfg(feature = "html_reports")]
+    {
+        let dir = tempdir.path().to_owned();
+        verify_html(&dir, "report/index.html");
+    }
 }
 
 #[cfg(feature = "plotters")]
@@ -389,24 +399,27 @@ fn test_output_files_flat_sampling() {
     verify_stats(&dir, "base");
     verify_json(&dir, "change/estimates.json");
 
-    verify_svg(&dir, "report/MAD.svg");
-    verify_svg(&dir, "report/mean.svg");
-    verify_svg(&dir, "report/median.svg");
-    verify_svg(&dir, "report/pdf.svg");
-    verify_svg(&dir, "report/iteration_times.svg");
-    verify_svg(&dir, "report/SD.svg");
-    verify_svg(&dir, "report/typical.svg");
-    verify_svg(&dir, "report/both/pdf.svg");
-    verify_svg(&dir, "report/both/iteration_times.svg");
-    verify_svg(&dir, "report/change/mean.svg");
-    verify_svg(&dir, "report/change/median.svg");
-    verify_svg(&dir, "report/change/t-test.svg");
+    #[cfg(feature = "html_reports")]
+    {
+        verify_svg(&dir, "report/MAD.svg");
+        verify_svg(&dir, "report/mean.svg");
+        verify_svg(&dir, "report/median.svg");
+        verify_svg(&dir, "report/pdf.svg");
+        verify_svg(&dir, "report/iteration_times.svg");
+        verify_svg(&dir, "report/SD.svg");
+        verify_svg(&dir, "report/typical.svg");
+        verify_svg(&dir, "report/both/pdf.svg");
+        verify_svg(&dir, "report/both/iteration_times.svg");
+        verify_svg(&dir, "report/change/mean.svg");
+        verify_svg(&dir, "report/change/median.svg");
+        verify_svg(&dir, "report/change/t-test.svg");
 
-    verify_svg(&dir, "report/pdf_small.svg");
-    verify_svg(&dir, "report/iteration_times_small.svg");
-    verify_svg(&dir, "report/relative_pdf_small.svg");
-    verify_svg(&dir, "report/relative_iteration_times_small.svg");
-    verify_html(&dir, "report/index.html");
+        verify_svg(&dir, "report/pdf_small.svg");
+        verify_svg(&dir, "report/iteration_times_small.svg");
+        verify_svg(&dir, "report/relative_pdf_small.svg");
+        verify_svg(&dir, "report/relative_iteration_times_small.svg");
+        verify_html(&dir, "report/index.html");
+    }
 }
 
 #[test]

--- a/tests/criterion_tests.rs
+++ b/tests/criterion_tests.rs
@@ -1,9 +1,10 @@
 use criterion;
 use serde_json;
 
+#[cfg(feature = "plotters")]
+use criterion::SamplingMode;
 use criterion::{
     criterion_group, criterion_main, profiler::Profiler, BatchSize, BenchmarkId, Criterion,
-    SamplingMode,
 };
 use serde_json::value::Value;
 use std::cell::{Cell, RefCell};


### PR DESCRIPTION
 - [x] `plotters` doesn't support wasm32-wasi. Make the dependency optional.
 - [x] JSON files cannot be written to disk. `--discard-baseline` prevents the baseline from being written to disk.
 - [x] Rayon doesn't support wasm32-wasi. Make the dependency optional.