### PR TITLE
Remove three unnecessary 'unsafe' blocks.

### DIFF
--- a/src/stats/univariate/percentiles.rs
+++ b/src/stats/univariate/percentiles.rs
@@ -54,27 +54,23 @@ where
 
     /// Returns the interquartile range
     pub fn iqr(&self) -> A {
-        unsafe {
-            let q1 = self.at_unchecked(A::cast(25));
-            let q3 = self.at_unchecked(A::cast(75));
+        let q1 = self.at(A::cast(25));
+        let q3 = self.at(A::cast(75));
 
-            q3 - q1
-        }
+        q3 - q1
     }
 
     /// Returns the 50th percentile
     pub fn median(&self) -> A {
-        unsafe { self.at_unchecked(A::cast(50)) }
+        self.at(A::cast(50))
     }
 
     /// Returns the 25th, 50th and 75th percentiles
     pub fn quartiles(&self) -> (A, A, A) {
-        unsafe {
-            (
-                self.at_unchecked(A::cast(25)),
-                self.at_unchecked(A::cast(50)),
-                self.at_unchecked(A::cast(75)),
-            )
-        }
+        (
+            self.at(A::cast(25)),
+            self.at(A::cast(50)),
+            self.at(A::cast(75)),
+        )
     }
 }

--- a/src/stats/univariate/sample.rs
+++ b/src/stats/univariate/sample.rs
@@ -13,6 +13,7 @@ use rayon::prelude::*;
 ///
 /// - The sample contains at least 2 data points
 /// - The sample contains no `NaN`s
+#[repr(transparent)]
 pub struct Sample<A>([A]);
 
 // TODO(rust-lang/rfcs#735) move this `impl` into a private percentiles module


### PR DESCRIPTION
The compiler can statically remove the assertions.