### PR TITLE
Add flag to allow baseline comparisons to succeed when a baseline cannot be found

### DIFF
--- a/book/src/user_guide/command_line_options.md
+++ b/book/src/user_guide/command_line_options.md
@@ -18,15 +18,16 @@ regular expression matching the benchmark ID. For example, running
 * To test that the benchmarks run successfully without performing the measurement or analysis (eg. in a CI setting), use `cargo test --benches`.
 * To override the default plotting backend, use `cargo bench -- --plotting-backend gnuplot` or `cargo bench --plotting-backend plotters`. `gnuplot` is used by default if it is installed.
 * To change the CLI output format, use `cargo bench -- --output-format <name>`. Supported output formats are:
- * `criterion` - Use Criterion's normal output format
- * `bencher` - An output format similar to the output produced by the `bencher` crate or nightly `libtest` benchmarks. Though this provides less information than the `criterion` format, it may be useful to support external tools that can parse this output.
+  * `criterion` - Use Criterion's normal output format
+  * `bencher` - An output format similar to the output produced by the `bencher` crate or nightly `libtest` benchmarks. Though this provides less information than the `criterion` format, it may be useful to support external tools that can parse this output.
 
 ## Baselines
 
 By default, Criterion.rs will compare the measurements against the previous run (if any). Sometimes it's useful to keep a set of measurements around for several runs. For example, you might want to make multiple changes to the code while comparing against the master branch. For this situation, Criterion.rs supports custom baselines.
 
-* `--save-baseline <name>` will compare against the named baseline, then overwrite it. 
-* `--baseline <name>` will compare against the named baseline without overwriting it.
+* `--save-baseline <name>` will compare against the named baseline, then overwrite it.
+* `--baseline <name>` will compare against the named baseline without overwriting it. Will fail if the specified baseline is missing any benchmark results.
+* `--baseline-lenient <name>` will compare against the named baseline without overwriting it. Will not fail if the specified baseline is missing any benchmark results. This is useful for automatically comparing benchmark results between branches in CI.
 * `--load-baseline <name>` will load the named baseline as the new data set rather than the previous baseline.
 
 Using these options, you can manage multiple baseline measurements. For instance, if you want to compare against a static reference point such as the master branch, you might run:

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -47,7 +47,7 @@ pub(crate) fn common<M: Measurement, T: ?Sized>(
 ) {
     criterion.report.benchmark_start(id, report_context);
 
-    if let Baseline::Compare = criterion.baseline {
+    if let Baseline::CompareStrict = criterion.baseline {
         if !base_dir_exists(
             id,
             &criterion.baseline_directory,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,9 +265,12 @@ impl BatchSize {
 /// Baseline describes how the baseline_directory is handled.
 #[derive(Debug, Clone, Copy)]
 pub enum Baseline {
-    /// Compare ensures a previous saved version of the baseline
-    /// exists and runs comparison against that.
-    Compare,
+    /// CompareLenient compares against a previous saved version of the baseline.
+    /// If a previous baseline does not exist, the benchmark is run as normal but no comparison occurs.
+    CompareLenient,
+    /// CompareStrict compares against a previous saved version of the baseline.
+    /// If a previous baseline does not exist, a panic occurs.
+    CompareStrict,
     /// Save writes the benchmark results to the baseline directory,
     /// overwriting any results that were previously there.
     Save,
@@ -636,9 +639,13 @@ impl<M: Measurement> Criterion<M> {
     }
 
     /// Names an explicit baseline and disables overwriting the previous results.
-    pub fn retain_baseline(mut self, baseline: String) -> Criterion<M> {
+    pub fn retain_baseline(mut self, baseline: String, strict: bool) -> Criterion<M> {
         self.baseline_directory = baseline;
-        self.baseline = Baseline::Compare;
+        self.baseline = if strict {
+            Baseline::CompareStrict
+        } else {
+            Baseline::CompareLenient
+        };
         self
     }
 
@@ -734,14 +741,19 @@ impl<M: Measurement> Criterion<M> {
                 .help("Save results under a named baseline."))
             .arg(Arg::with_name("discard-baseline")
                 .long("discard-baseline")
-                .conflicts_with_all(&["save-baseline", "baseline"])
+                .conflicts_with_all(&["save-baseline", "baseline", "baseline-lenient"])
                 .help("Discard benchmark results."))
             .arg(Arg::with_name("baseline")
                 .short("b")
                 .long("baseline")
                 .takes_value(true)
-                .conflicts_with("save-baseline")
-                .help("Compare to a named baseline."))
+                .conflicts_with_all(&["save-baseline", "baseline-lenient"])
+                .help("Compare to a named baseline. If any benchmarks do not have the specified baseline this command fails."))
+            .arg(Arg::with_name("baseline-lenient")
+                .long("baseline-lenient")
+                .takes_value(true)
+                .conflicts_with_all(&["save-baseline", "baseline"])
+                .help("Compare to a named baseline. If any benchmarks do not have the specified baseline then just those benchmarks are not compared against the baseline while every other benchmark is compared against the baseline."))
             .arg(Arg::with_name("list")
                 .long("list")
                 .help("List all benchmarks")
@@ -917,7 +929,11 @@ https://bheisler.github.io/criterion.rs/book/faq.html
             self.baseline = Baseline::Discard;
         }
         if let Some(dir) = matches.value_of("baseline") {
-            self.baseline = Baseline::Compare;
+            self.baseline = Baseline::CompareStrict;
+            self.baseline_directory = dir.to_owned();
+        }
+        if let Some(dir) = matches.value_of("baseline-lenient") {
+            self.baseline = Baseline::CompareLenient;
             self.baseline_directory = dir.to_owned();
         }
 

--- a/tests/criterion_tests.rs
+++ b/tests/criterion_tests.rs
@@ -165,7 +165,7 @@ fn test_retain_baseline() {
     let pre_modified = latest_modified(&dir.path().join("test_retain_baseline/some-baseline"));
 
     short_benchmark(&dir)
-        .retain_baseline("some-baseline".to_owned())
+        .retain_baseline("some-baseline".to_owned(), true)
         .bench_function("test_retain_baseline", |b| b.iter(|| 10));
 
     let post_modified = latest_modified(&dir.path().join("test_retain_baseline/some-baseline"));
@@ -175,11 +175,18 @@ fn test_retain_baseline() {
 
 #[test]
 #[should_panic(expected = "Baseline 'some-baseline' must exist before comparison is allowed")]
-fn test_compare_baseline() {
-    // Initial benchmark to populate
+fn test_compare_baseline_strict_panics_when_missing_baseline() {
     let dir = temp_dir();
     short_benchmark(&dir)
-        .retain_baseline("some-baseline".to_owned())
+        .retain_baseline("some-baseline".to_owned(), true)
+        .bench_function("test_compare_baseline", |b| b.iter(|| 10));
+}
+
+#[test]
+fn test_compare_baseline_lenient_when_missing_baseline() {
+    let dir = temp_dir();
+    short_benchmark(&dir)
+        .retain_baseline("some-baseline".to_owned(), false)
         .bench_function("test_compare_baseline", |b| b.iter(|| 10));
 }
 


### PR DESCRIPTION
closes https://github.com/bheisler/criterion.rs/issues/530
The usecase for this functionality is outlined in the issue.

The old functionality is maintained by default in the command line and a new flag --baseline-lenient is added to provide the new functionality.

Happy to completely rewrite the API I am exposing here.
I dont have much opinions other than the fact I would like some way to access this functionality.
