### PR TITLE
Enable --quick mode.

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -19,6 +19,7 @@
     - [Profiling](./user_guide/profiling.md)
     - [Custom Test Framework](./user_guide/custom_test_framework.md)
     - [Benchmarking async functions](./user_guide/benchmarking_async.md)
+    - [Quick Mode](./user_guide/quick_mode.md)
 - [cargo-criterion](./cargo_criterion/cargo_criterion.md)
   - [Configuring cargo-criterion](./cargo_criterion/configuring_cargo_criterion.md)
   - [External Tools](./cargo_criterion/external_tools.md)

--- a/book/src/user_guide/command_line_options.md
+++ b/book/src/user_guide/command_line_options.md
@@ -20,6 +20,7 @@ regular expression matching the benchmark ID. For example, running
 * To change the CLI output format, use `cargo bench -- --output-format <name>`. Supported output formats are:
  * `criterion` - Use Criterion's normal output format
  * `bencher` - An output format similar to the output produced by the `bencher` crate or nightly `libtest` benchmarks. Though this provides less information than the `criterion` format, it may be useful to support external tools that can parse this output.
+* To run benchmarks quicker but with lower statistical guarantees, use `cargo bench -- --quick`
 
 ## Baselines
 

--- a/book/src/user_guide/quick_mode.md
+++ b/book/src/user_guide/quick_mode.md
@@ -9,7 +9,7 @@ Quick mode in criterion works exactly like `tasty-bench` which has a wealth of d
 1. Set n ← 1.
 1. Measure execution time tₙ of n iterations and execution time t₂ₙ of 2n iterations.
 1. Find t which minimizes deviation of (nt, 2nt) from (tₙ, t₂ₙ), namely t ← (tₙ + 2t₂ₙ) / 5n.
-1. If deviation is small enough (see --stdev below) or time is running out soon (see --timeout below), return t as a mean execution time.
+1. If deviation is small enough (see `--significance-level`) or time has run out (see `--measurement-time`), return t as a mean execution time.
 1. Otherwise set n ← 2n and jump back to Step 2.
 
 ### Disclaimer

--- a/book/src/user_guide/quick_mode.md
+++ b/book/src/user_guide/quick_mode.md
@@ -1,0 +1,17 @@
+## Quick mode
+
+Quick mode is enabled with the `--quick` flag and tells criterion to stop benchmarks early once the significance level is below a certail value (default 5%, see the `--significance-level` flag).
+
+Quick mode in criterion works exactly like `tasty-bench` which has a wealth of details: https://github.com/Bodigrim/tasty-bench
+
+### Statistical model
+
+1. Set n ← 1.
+1. Measure execution time tₙ of n iterations and execution time t₂ₙ of 2n iterations.
+1. Find t which minimizes deviation of (nt, 2nt) from (tₙ, t₂ₙ), namely t ← (tₙ + 2t₂ₙ) / 5n.
+1. If deviation is small enough (see --stdev below) or time is running out soon (see --timeout below), return t as a mean execution time.
+1. Otherwise set n ← 2n and jump back to Step 2.
+
+### Disclaimer
+
+Statistics is a tricky matter, there is no one-size-fits-all approach. In the absence of a good theory simplistic approaches are as (un)sound as obscure ones. Those who seek statistical soundness should rather collect raw data and process it themselves using a proper statistical toolbox. Data reported by criterion in quick mode is only of indicative and comparative significance.

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -13,6 +13,7 @@ pub struct BenchmarkConfig {
     pub significance_level: f64,
     pub warm_up_time: Duration,
     pub sampling_mode: SamplingMode,
+    pub quick_mode: bool,
 }
 
 /// Struct representing a partially-complete per-benchmark configuration.
@@ -26,6 +27,7 @@ pub(crate) struct PartialBenchmarkConfig {
     pub(crate) significance_level: Option<f64>,
     pub(crate) warm_up_time: Option<Duration>,
     pub(crate) sampling_mode: Option<SamplingMode>,
+    pub(crate) quick_mode: Option<bool>,
     pub(crate) plot_config: PlotConfiguration,
 }
 
@@ -42,6 +44,7 @@ impl PartialBenchmarkConfig {
                 .unwrap_or(defaults.significance_level),
             warm_up_time: self.warm_up_time.unwrap_or(defaults.warm_up_time),
             sampling_mode: self.sampling_mode.unwrap_or(defaults.sampling_mode),
+            quick_mode: self.quick_mode.unwrap_or(defaults.quick_mode),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -400,6 +400,7 @@ impl Default for Criterion {
                 significance_level: 0.05,
                 warm_up_time: Duration::from_secs(3),
                 sampling_mode: SamplingMode::Auto,
+                quick_mode: false,
             },
             filter: None,
             report: reports,
@@ -785,6 +786,10 @@ impl<M: Measurement> Criterion<M> {
                 .long("significance-level")
                 .takes_value(true)
                 .help(&format!("Changes the default significance level for this run. [default: {}]", self.config.significance_level)))
+            .arg(Arg::with_name("quick")
+                .long("quick")
+                .conflicts_with("sample-size")
+                .help(&format!("Benchmark only until the significance level has been reached [default: {}]", self.config.quick_mode)))
             .arg(Arg::with_name("test")
                 .hidden(true)
                 .long("test")
@@ -1042,6 +1047,10 @@ https://bheisler.github.io/criterion.rs/book/faq.html
             assert!(num_significance_level > 0.0 && num_significance_level < 1.0);
 
             self.config.significance_level = num_significance_level;
+        }
+
+        if matches.is_present("quick") {
+            self.config.quick_mode = true;
         }
 
         self


### PR DESCRIPTION
The `--quick` will run benchmarks until two successive sample runs have a standard deviation of less than 5% (set by `--significance-level`). This is often vastly quicker than running the benchmarks for 8 seconds (which is the normal default).

Quick mode will bail if a benchmark takes more than 5 seconds even if this leads to a significance level worse than 5%.

Here are the output for the `num-bigint` benchmarks. Summary: The results are essentially identical but `--quick` is nearly 50 times faster.

<details>
 <summary>Results from num-bigint (green and red numbers should be roughly the same)</summary>

```diff
1,4c1,4
< multiply/0              time:   [55.056 ns 55.186 ns 55.303 ns]
< multiply/1              time:   [4.2871 us 4.2913 us 4.2963 us]
< multiply/2              time:   [296.46 us 296.79 us 297.17 us]
< multiply/3              time:   [681.55 us 682.66 us 683.98 us]
---
> multiply/0              time:   [54.344 ns 54.491 ns 54.528 ns]
> multiply/1              time:   [4.2606 us 4.2623 us 4.2627 us]
> multiply/2              time:   [295.97 us 296.04 us 296.32 us]
> multiply/3              time:   [678.97 us 679.89 us 680.12 us]
6,9c6,9
< divide/0                time:   [142.55 ns 144.30 ns 145.72 ns]
< divide/1                time:   [1.9986 us 2.0004 us 2.0029 us]
< divide/2                time:   [108.60 us 108.69 us 108.80 us]
< divide/big_little       time:   [8.4901 us 8.4976 us 8.5087 us]
---
> divide/0                time:   [147.23 ns 147.37 ns 147.40 ns]
> divide/1                time:   [1.9957 us 1.9967 us 1.9969 us]
> divide/2                time:   [108.24 us 108.27 us 108.36 us]
> divide/big_little       time:   [8.4814 us 8.4843 us 8.4851 us]
11,14c11,14
< remainder/0             time:   [142.18 ns 143.12 ns 144.10 ns]
< remainder/1             time:   [2.0084 us 2.0099 us 2.0116 us]
< remainder/2             time:   [108.81 us 109.08 us 109.56 us]
< remainder/big_little    time:   [8.4988 us 8.5071 us 8.5168 us]
---
> remainder/0             time:   [137.63 ns 137.66 ns 137.67 ns]
> remainder/1             time:   [1.9948 us 1.9995 us 2.0007 us]
> remainder/2             time:   [108.46 us 108.81 us 108.89 us]
> remainder/big_little    time:   [8.4616 us 8.4686 us 8.4703 us]
16c16
< factorial_100           time:   [3.6589 us 3.6619 us 3.6648 us]
---
> factorial_100           time:   [3.5835 us 3.5872 us 3.6020 us]
18,20c18,20
< fib/100                 time:   [511.08 ns 513.43 ns 515.71 ns]
< fib/1000                time:   [8.2768 us 8.2930 us 8.3076 us]
< fib/10000               time:   [666.89 us 668.28 us 669.90 us]
---
> fib/100                 time:   [486.53 ns 486.75 ns 486.81 ns]
> fib/1000                time:   [8.1450 us 8.1595 us 8.2177 us]
> fib/10000               time:   [663.09 us 663.78 us 663.96 us]
22,24c22,24
< fib2/100                time:   [699.27 ns 700.81 ns 702.33 ns]
< fib2/1000               time:   [17.179 us 17.190 us 17.203 us]
< fib2/10000              time:   [1.4649 ms 1.4688 ms 1.4722 ms]
---
> fib2/100                time:   [669.57 ns 669.69 ns 670.19 ns]
> fib2/1000               time:   [17.154 us 17.155 us 17.155 us]
> fib2/10000              time:   [1.4571 ms 1.4599 ms 1.4606 ms]
26c26
< fib_u128                time:   [205.98 ns 206.06 ns 206.15 ns]
---
> fib_u128                time:   [206.17 ns 206.35 ns 207.09 ns]
28c28
< fac_to_string           time:   [736.78 ns 737.28 ns 737.85 ns]
---
> fac_to_string           time:   [734.45 ns 734.55 ns 734.92 ns]
30c30
< fib_to_string           time:   [185.85 ns 186.43 ns 187.06 ns]
---
> fib_to_string           time:   [181.47 ns 181.97 ns 183.97 ns]
32,36c32,36
< to_str_radix/02         time:   [2.4083 us 2.4091 us 2.4101 us]
< to_str_radix/08         time:   [873.67 ns 874.02 ns 874.42 ns]
< to_str_radix/10         time:   [2.0992 us 2.0999 us 2.1007 us]
< to_str_radix/16         time:   [672.69 ns 673.16 ns 673.64 ns]
< to_str_radix/36         time:   [1.7619 us 1.7625 us 1.7633 us]
---
> to_str_radix/02         time:   [2.4065 us 2.4161 us 2.4185 us]
> to_str_radix/08         time:   [891.42 ns 907.88 ns 912.00 ns]
> to_str_radix/10         time:   [2.1090 us 2.1105 us 2.1109 us]
> to_str_radix/16         time:   [707.96 ns 708.25 ns 709.42 ns]
> to_str_radix/36         time:   [1.7511 us 1.7516 us 1.7518 us]
39c39
<                         time:   [2.6496 us 2.6514 us 2.6537 us]
---
>                         time:   [2.6515 us 2.6538 us 2.6632 us]
41c41
<                         time:   [1.0317 us 1.0320 us 1.0322 us]
---
>                         time:   [1.0216 us 1.0225 us 1.0260 us]
43c43
<                         time:   [968.06 ns 970.68 ns 973.03 ns]
---
>                         time:   [962.00 ns 962.04 ns 962.23 ns]
45c45
<                         time:   [752.55 ns 754.44 ns 756.10 ns]
---
>                         time:   [748.35 ns 748.71 ns 748.80 ns]
47c47
<                         time:   [742.76 ns 743.29 ns 743.95 ns]
---
>                         time:   [727.73 ns 727.87 ns 728.43 ns]
49,56c49,56
< rand/64                 time:   [33.233 ns 33.243 ns 33.255 ns]
< rand/256                time:   [41.077 ns 41.088 ns 41.101 ns]
< rand/1009               time:   [69.727 ns 69.794 ns 69.861 ns]
< rand/2048               time:   [137.67 ns 137.76 ns 137.85 ns]
< rand/4096               time:   [213.23 ns 213.31 ns 213.39 ns]
< rand/8192               time:   [326.79 ns 327.56 ns 328.34 ns]
< rand/65536              time:   [2.4155 us 2.4191 us 2.4219 us]
< rand/131072             time:   [4.7683 us 4.7754 us 4.7811 us]
---
> rand/64                 time:   [33.223 ns 33.331 ns 33.358 ns]
> rand/256                time:   [40.364 ns 40.380 ns 40.384 ns]
> rand/1009               time:   [70.404 ns 70.441 ns 70.588 ns]
> rand/2048               time:   [134.38 ns 134.48 ns 134.50 ns]
> rand/4096               time:   [209.72 ns 210.24 ns 212.33 ns]
> rand/8192               time:   [325.38 ns 325.83 ns 327.65 ns]
> rand/65536              time:   [2.3830 us 2.3859 us 2.3867 us]
> rand/131072             time:   [4.7009 us 4.7015 us 4.7040 us]
58c58
< shl                     time:   [530.46 ns 533.75 ns 536.83 ns]
---
> shl                     time:   [505.88 ns 506.05 ns 506.73 ns]
60c60
< shr                     time:   [739.73 ns 740.18 ns 740.72 ns]
---
> shr                     time:   [723.75 ns 723.80 ns 724.02 ns]
62c62
< hahs                    time:   [92.718 us 92.914 us 93.128 us]
---
> hahs                    time:   [90.486 us 90.660 us 90.703 us]
64c64
< pow_bench               time:   [4.8609 ms 4.8844 ms 4.9069 ms]
---
> pow_bench               time:   [5.0119 ms 5.0126 ms 5.0157 ms]
66,71c66,71
< pow/pow_bench_bigexp    time:   [4.7814 ms 4.7901 ms 4.7990 ms]
< pow/1e1000              time:   [1.5985 us 1.6008 us 1.6033 us]
< pow/1e10000             time:   [48.136 us 48.186 us 48.252 us]
< pow/1e100000            time:   [1.5990 ms 1.6010 ms 1.6029 ms]
< pow/modpow              time:   [3.7093 ms 3.7134 ms 3.7183 ms]
< pow/modpow_even         time:   [9.9251 ms 9.9453 ms 9.9664 ms]
---
> pow/pow_bench_bigexp    time:   [4.8592 ms 4.8604 ms 4.8654 ms]
> pow/1e1000              time:   [1.5895 us 1.5920 us 1.5926 us]
> pow/1e10000             time:   [47.114 us 47.165 us 47.368 us]
> pow/1e100000            time:   [1.5725 ms 1.5736 ms 1.5738 ms]
> pow/modpow              time:   [3.6999 ms 3.7026 ms 3.7033 ms]
> pow/modpow_even         time:   [9.8553 ms 9.8948 ms 9.9047 ms]
73,76c73,76
< iters/to_u32_digits     time:   [111.99 ns 113.03 ns 113.98 ns]
< iters/iter_u32_digits   time:   [36.047 ns 36.139 ns 36.223 ns]
< iters/to_u64_digits     time:   [85.593 ns 87.416 ns 89.513 ns]
< iters/iter_u64_digits   time:   [49.139 ns 49.509 ns 49.924 ns]
---
> iters/to_u32_digits     time:   [114.97 ns 115.02 ns 115.23 ns]
> iters/iter_u32_digits   time:   [35.934 ns 35.946 ns 35.991 ns]
> iters/to_u64_digits     time:   [92.678 ns 92.687 ns 92.689 ns]
> iters/iter_u64_digits   time:   [47.613 ns 47.718 ns 47.744 ns]
78c78
< total time: 8m 43s
---
> total time: 11s

```

</details>

