### PR TITLE
Disable nightly testing.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,6 @@ jobs:
         rust:
           - stable
           - beta
-          - nightly
           - 1.46.0  # MSRV
 
     steps:


### PR DESCRIPTION
It's too finicky to be of use. We still test with 1.46 (MSRV), stable, and beta.