### PR TITLE
bench_with_input now takes an FnOnce instead of raw input

### DIFF
--- a/benches/benchmarks/compare_functions.rs
+++ b/benches/benchmarks/compare_functions.rs
@@ -27,18 +27,22 @@ fn fibonacci_fast(n: u64) -> u64 {
 fn compare_fibonaccis(c: &mut Criterion) {
     let mut group = c.benchmark_group("Fibonacci");
 
-    group.bench_with_input("Recursive", &20, |b, i| b.iter(|| fibonacci_slow(*i)));
-    group.bench_with_input("Iterative", &20, |b, i| b.iter(|| fibonacci_fast(*i)));
+    group.bench_with_input("Recursive", || 20, |b, i| b.iter(|| fibonacci_slow(*i)));
+    group.bench_with_input("Iterative", || 20, |b, i| b.iter(|| fibonacci_fast(*i)));
 }
 fn compare_fibonaccis_group(c: &mut Criterion) {
     let mut group = c.benchmark_group("Fibonacci3");
     for i in 20..=21 {
-        group.bench_with_input(BenchmarkId::new("Recursive", i), &i, |b, i| {
-            b.iter(|| fibonacci_slow(*i))
-        });
-        group.bench_with_input(BenchmarkId::new("Iterative", i), &i, |b, i| {
-            b.iter(|| fibonacci_fast(*i))
-        });
+        group.bench_with_input(
+            BenchmarkId::new("Recursive", i),
+            || i,
+            |b, i| b.iter(|| fibonacci_slow(*i)),
+        );
+        group.bench_with_input(
+            BenchmarkId::new("Iterative", i),
+            || i,
+            |b, i| b.iter(|| fibonacci_fast(*i)),
+        );
     }
     group.finish()
 }

--- a/benches/benchmarks/with_inputs.rs
+++ b/benches/benchmarks/with_inputs.rs
@@ -8,9 +8,13 @@ fn from_elem(c: &mut Criterion) {
     let mut group = c.benchmark_group("from_elem");
     for size in [KB, 2 * KB, 4 * KB, 8 * KB, 16 * KB].iter() {
         group.throughput(Throughput::Bytes(*size as u64));
-        group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
-            b.iter(|| iter::repeat(0u8).take(size).collect::<Vec<_>>());
-        });
+        group.bench_with_input(
+            BenchmarkId::from_parameter(size),
+            || size,
+            |b, size| {
+                b.iter(|| iter::repeat(0u8).take(**size).collect::<Vec<_>>());
+            },
+        );
     }
     group.finish();
 }

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -42,7 +42,7 @@ pub(crate) fn common<M: Measurement, T: ?Sized>(
     config: &BenchmarkConfig,
     criterion: &Criterion<M>,
     report_context: &ReportContext,
-    parameter: &T,
+    parameter: &mut T,
     throughput: Option<Throughput>,
 ) {
     criterion.report.benchmark_start(id, report_context);

--- a/src/benchmark_group.rs
+++ b/src/benchmark_group.rs
@@ -263,7 +263,7 @@ impl<'a, M: Measurement> BenchmarkGroup<'a, M> {
         f: F,
     ) -> &mut Self
     where
-        F: FnMut(&mut Bencher<'_, M>, &I),
+        F: FnMut(&mut Bencher<'_, M>, &mut I),
         InputFn: FnOnce() -> I,
     {
         self.run_bench(id.into_benchmark_id(), input, f);
@@ -272,7 +272,7 @@ impl<'a, M: Measurement> BenchmarkGroup<'a, M> {
 
     fn run_bench<F, InputFn, I>(&mut self, id: BenchmarkId, input: InputFn, f: F)
     where
-        F: FnMut(&mut Bencher<'_, M>, &I),
+        F: FnMut(&mut Bencher<'_, M>, &mut I),
         InputFn: FnOnce() -> I,
     {
         let config = self.partial_config.to_complete(&self.criterion.config);
@@ -322,7 +322,7 @@ impl<'a, M: Measurement> BenchmarkGroup<'a, M> {
                         &config,
                         self.criterion,
                         &report_context,
-                        &input(),
+                        &mut input(),
                         self.throughput.clone(),
                     );
                 }
@@ -336,7 +336,7 @@ impl<'a, M: Measurement> BenchmarkGroup<'a, M> {
                 if do_run {
                     // In test mode, run the benchmark exactly once, then exit.
                     self.criterion.report.test_start(&id, &report_context);
-                    func.test(&self.criterion.measurement, &input());
+                    func.test(&self.criterion.measurement, &mut input());
                     self.criterion.report.test_pass(&id, &report_context);
                 }
             }
@@ -348,7 +348,7 @@ impl<'a, M: Measurement> BenchmarkGroup<'a, M> {
                         self.criterion,
                         &report_context,
                         duration,
-                        &input(),
+                        &mut input(),
                     );
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1186,7 +1186,7 @@ where
         f: F,
     ) -> &mut Criterion<M>
     where
-        F: FnMut(&mut Bencher<'_, M>, &I),
+        F: FnMut(&mut Bencher<'_, M>, &mut I),
         InputFn: FnOnce() -> I,
     {
         // It's possible to use BenchmarkId::from_parameter to create a benchmark ID with no function

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1169,7 +1169,8 @@ where
     ///     // Setup (construct data, allocate memory, etc)
     ///     let input = 5u64;
     ///     c.bench_with_input(
-    ///         BenchmarkId::new("function_name", input), &input,
+    ///         BenchmarkId::new("function_name", input),
+    ///         || input,
     ///         |b, i| b.iter(|| {
     ///             // Code to benchmark using input `i` goes here
     ///         }),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1179,9 +1179,15 @@ where
     /// criterion_group!(benches, bench);
     /// criterion_main!(benches);
     /// ```
-    pub fn bench_with_input<F, I>(&mut self, id: BenchmarkId, input: &I, f: F) -> &mut Criterion<M>
+    pub fn bench_with_input<F, I, InputFn>(
+        &mut self,
+        id: BenchmarkId,
+        input: InputFn,
+        f: F,
+    ) -> &mut Criterion<M>
     where
         F: FnMut(&mut Bencher<'_, M>, &I),
+        InputFn: FnOnce() -> I,
     {
         // It's possible to use BenchmarkId::from_parameter to create a benchmark ID with no function
         // name. That's intended for use with BenchmarkGroups where the function name isn't necessary,

--- a/src/routine.rs
+++ b/src/routine.rs
@@ -9,12 +9,12 @@ use std::time::Duration;
 /// PRIVATE
 pub(crate) trait Routine<M: Measurement, T: ?Sized> {
     /// PRIVATE
-    fn bench(&mut self, m: &M, iters: &[u64], parameter: &T) -> Vec<f64>;
+    fn bench(&mut self, m: &M, iters: &[u64], parameter: &mut T) -> Vec<f64>;
     /// PRIVATE
-    fn warm_up(&mut self, m: &M, how_long: Duration, parameter: &T) -> (u64, u64);
+    fn warm_up(&mut self, m: &M, how_long: Duration, parameter: &mut T) -> (u64, u64);
 
     /// PRIVATE
-    fn test(&mut self, m: &M, parameter: &T) {
+    fn test(&mut self, m: &M, parameter: &mut T) {
         self.bench(m, &[1u64], parameter);
     }
 
@@ -30,7 +30,7 @@ pub(crate) trait Routine<M: Measurement, T: ?Sized> {
         criterion: &Criterion<M>,
         report_context: &ReportContext,
         time: Duration,
-        parameter: &T,
+        parameter: &mut T,
     ) {
         criterion
             .report
@@ -86,7 +86,7 @@ pub(crate) trait Routine<M: Measurement, T: ?Sized> {
         config: &BenchmarkConfig,
         criterion: &Criterion<M>,
         report_context: &ReportContext,
-        parameter: &T,
+        parameter: &mut T,
     ) -> (ActualSamplingMode, Box<[f64]>, Box<[f64]>) {
         if config.quick_mode {
             let minimum_bench_duration = Duration::from_millis(100);
@@ -205,7 +205,7 @@ pub(crate) trait Routine<M: Measurement, T: ?Sized> {
 
 pub struct Function<M: Measurement, F, T>
 where
-    F: FnMut(&mut Bencher<'_, M>, &T),
+    F: FnMut(&mut Bencher<'_, M>, &mut T),
     T: ?Sized,
 {
     f: F,
@@ -215,7 +215,7 @@ where
 }
 impl<M: Measurement, F, T> Function<M, F, T>
 where
-    F: FnMut(&mut Bencher<'_, M>, &T),
+    F: FnMut(&mut Bencher<'_, M>, &mut T),
     T: ?Sized,
 {
     pub fn new(f: F) -> Function<M, F, T> {
@@ -229,10 +229,10 @@ where
 
 impl<M: Measurement, F, T> Routine<M, T> for Function<M, F, T>
 where
-    F: FnMut(&mut Bencher<'_, M>, &T),
+    F: FnMut(&mut Bencher<'_, M>, &mut T),
     T: ?Sized,
 {
-    fn bench(&mut self, m: &M, iters: &[u64], parameter: &T) -> Vec<f64> {
+    fn bench(&mut self, m: &M, iters: &[u64], parameter: &mut T) -> Vec<f64> {
         let f = &mut self.f;
 
         let mut b = Bencher {
@@ -254,7 +254,7 @@ where
             .collect()
     }
 
-    fn warm_up(&mut self, m: &M, how_long: Duration, parameter: &T) -> (u64, u64) {
+    fn warm_up(&mut self, m: &M, how_long: Duration, parameter: &mut T) -> (u64, u64) {
         let f = &mut self.f;
         let mut b = Bencher {
             iterated: false,

--- a/tests/criterion_tests.rs
+++ b/tests/criterion_tests.rs
@@ -443,8 +443,8 @@ fn test_benchmark_group_with_input() {
     let mut c = short_benchmark(&dir);
     let mut group = c.benchmark_group("Test Group");
     for x in 0..2 {
-        group.bench_with_input(BenchmarkId::new("Test 1", x), || x, |b, i| b.iter(|| i));
-        group.bench_with_input(BenchmarkId::new("Test 2", x), || x, |b, i| b.iter(|| i));
+        group.bench_with_input(BenchmarkId::new("Test 1", x), || x, |b, i| b.iter(|| *i));
+        group.bench_with_input(BenchmarkId::new("Test 2", x), || x, |b, i| b.iter(|| *i));
     }
     group.finish();
 }

--- a/tests/criterion_tests.rs
+++ b/tests/criterion_tests.rs
@@ -443,8 +443,8 @@ fn test_benchmark_group_with_input() {
     let mut c = short_benchmark(&dir);
     let mut group = c.benchmark_group("Test Group");
     for x in 0..2 {
-        group.bench_with_input(BenchmarkId::new("Test 1", x), &x, |b, i| b.iter(|| i));
-        group.bench_with_input(BenchmarkId::new("Test 2", x), &x, |b, i| b.iter(|| i));
+        group.bench_with_input(BenchmarkId::new("Test 1", x), || x, |b, i| b.iter(|| i));
+        group.bench_with_input(BenchmarkId::new("Test 2", x), || x, |b, i| b.iter(|| i));
     }
     group.finish();
 }


### PR DESCRIPTION
closes https://github.com/bheisler/criterion.rs/issues/514

I chose to alter bench_with_input to add this functionality because it can still be used for the original use case by just adding `||` to make the value into a closure.
Having one multipurpose function instead of 2 keeps the API simpler.
It also encourages users to generate their input lazily when possible.
But I dont feel strongly about this and im happy to go for any other design that solves #514 that you might suggest.

Making the input provided to the bench function always mutable is needed so that we can use things like a connection type in the input.
For an example of this you can refer to https://github.com/shotover/shotover-proxy/pull/514/files