### PR TITLE
Use main macro from imported section in iai example

### DIFF
--- a/book/src/iai/getting_started.md
+++ b/book/src/iai/getting_started.md
@@ -34,7 +34,7 @@ fn iai_benchmark_long() -> u64 {
 }
 
 
-iai::main!(iai_benchmark_short, iai_benchmark_long);
+main!(iai_benchmark_short, iai_benchmark_long);
 ```
 
 Finally, run this benchmark with `cargo bench`. You should see output similar to the following:


### PR DESCRIPTION
Use `main!` macro directly instead of `iai::main!` since it is already imported