### PR TITLE
Update regex version due to CVE

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ cast           = "0.2"
 num-traits     = { version = "0.2", default-features = false }
 oorandom       = "11.1"
 rayon          = "1.3"
-regex          = { version = "1.3", default-features = false, features = ["std"] }
+regex          = { version = "1.5.5", default-features = false, features = ["std"] }
 futures        = { version = "0.3", default_features = false, optional = true }
 smol           = { version = "1.2", default-features = false, optional = true }
 tokio          = { version = "1.0", default-features = false, features = ["rt"], optional = true }


### PR DESCRIPTION
See CVE: https://blog.rust-lang.org/2022/03/08/cve-2022-24713.html

It looks like the following lines are potentially susceptible to this security vulnerability, as the regex text is passed in through a public API:
https://github.com/bheisler/criterion.rs/blob/970aa04aa5ee0514d1930c83a58c6ca994727567/src/lib.rs#L676-L689

Thus tools and libraries dependent on Criterion.rs might pass in user-provided input.

Closes #524.
Closes #525.