### PR TITLE
Use the proper unit for microseconds

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -12,7 +12,7 @@ pub fn time(ns: f64) -> String {
     } else if ns < 10f64.powi(3) {
         format!("{:>6} ns", short(ns))
     } else if ns < 10f64.powi(6) {
-        format!("{:>6} us", short(ns / 1e3))
+        format!("{:>6} µs", short(ns / 1e3))
     } else if ns < 10f64.powi(9) {
         format!("{:>6} ms", short(ns / 1e6))
     } else {

--- a/src/measurement.rs
+++ b/src/measurement.rs
@@ -164,7 +164,7 @@ impl ValueFormatter for DurationFormatter {
         } else if ns < 10f64.powi(3) {
             (10f64.powi(0), "ns")
         } else if ns < 10f64.powi(6) {
-            (10f64.powi(-3), "us")
+            (10f64.powi(-3), "µs")
         } else if ns < 10f64.powi(9) {
             (10f64.powi(-6), "ms")
         } else {


### PR DESCRIPTION
Using `us` instead of `µs` is ok in ASCII-only environments, but the vast majority of environments where criterion is going to be used properly support Unicode.