### PR TITLE
set minimum patch version for atty

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ serde          = "1.0"
 serde_json     = "1.0"
 serde_derive   = "1.0"
 serde_cbor     = "0.11"
-atty           = "0.2"
+atty           = "~0.2.6"
 clap           = { version = "2.33", default-features = false }
 csv            = "1.1"
 walkdir        = "2.3"
@@ -64,7 +64,7 @@ real_blackbox = []
 # Enable async/await support
 async = ["futures"]
 
-# These features enable built-in support for running async benchmarks on each different async 
+# These features enable built-in support for running async benchmarks on each different async
 # runtime.
 async_futures = ["futures/executor", "async"]
 async_smol    = ["smol", "async"]


### PR DESCRIPTION
atty <= 0.2.5 depends on winapi 0.2, which does not compile w/ nightly
rust. Example output (rust version 1.64.0-nightly (c80c4b8fd 2022-06-26)):

```
error[E0592]: duplicate definitions with name `item`
--> C:\Users\runneradmin\.cargo\registry\src\github.com-1ecc6299db9ec823\winapi-0.2.4\src\macros.rs:134:13
|
134|            pub unsafe fn $variant(&self) -> &$fieldtype {
| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
| |
| duplicate definitions for `item`
| other definition for `item`
|
::: C:\Users\runneradmin\.cargo\registry\src\github.com-1ecc6299db9ec823\winapi-0.2.4\src\commctrl.rs:2889:1
|
2889|UNION!(TVINSERTSTRUCTA, itemex, item, item_mut, TV_ITEMA);
| ---------------------------------------------------------in this macro invocation
|
= note: this error originates in the macro `UNION` (in Nightly builds, run with -Z macro-backtrace for more info)
error[E0592]: duplicate definitions with name `item_mut`
--> C:\Users\runneradmin\.cargo\registry\src\github.com-1ecc6299db9ec823\winapi-0.2.4\src\macros.rs:138:13
|
138|            pub unsafe fn $variantmut(&mut self) -> &mut $fieldtype {
| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
| |
| duplicate definitions for `item_mut`
| other definition for `item_mut`
|
::: C:\Users\runneradmin\.cargo\registry\src\github.com-1ecc6299db9ec823\winapi-0.2.4\src\commctrl.rs:2889:1
|
2889|UNION!(TVINSERTSTRUCTA, itemex, item, item_mut, TV_ITEMA);
| ---------------------------------------------------------in this macro invocation
|
= note: this error originates in the macro `UNION` (in Nightly builds, run with -Z macro-backtrace for more info)
```

I'm using https://github.com/taiki-e/cargo-minimal-versions to test if
my library passes tests w/ minimal versions and currently it fails
because of atty / this crate. See https://github.com/webrtc-rs/sdp/runs/7072368640?check_suite_focus=true