### PR TITLE
deps(criterion-plot): update 'cast' to 0.3, following the rest of criterion

### DIFF
--- a/plot/Cargo.toml
+++ b/plot/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["visualization"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-cast = "0.2"
+cast = "0.3"
 itertools = "0.10"
 
 [dev-dependencies]


### PR DESCRIPTION
Since there was no conflict at compilation before, `cast` should be an internal-only dependency of
`criterion-plot` which means a patch update is possible without breaking compatibility AFAICT.