### PR TITLE
criterion-plot: update cast to 0.3

### DIFF
--- a/plot/Cargo.toml
+++ b/plot/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["visualization"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-cast = "0.2"
+cast = "0.3"
 itertools = "0.10"
 
 [dev-dependencies]


### PR DESCRIPTION
This major version of the `cast` crate matches the one used by the main `criterion` crate, eliminating the usage of several version of the aforementioned crate by Cargo, which very slightly reduces build times. As far as I know, there are no breaking changes that affect this crate.