### PR TITLE
Add nextest compatibility

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,8 @@ on:
       - version-0.4
 
 name: tests
+env:
+  CARGO_TERM_COLOR: always
 
 jobs:
   ci:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,3 +86,27 @@ jobs:
           export PATH=$HOME/.wasmtime/bin/:$PATH
           cargo install cargo-wasi
           cargo wasi bench --no-default-features -- --test
+
+  nextest-compat:
+    name: Check compatibility with nextest
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v1
+
+      - uses: taiki-e/install-action@nextest
+
+      - run: ci/nextest-compat.sh

--- a/ci/nextest-compat.sh
+++ b/ci/nextest-compat.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -ex -o pipefail
+
+CARGO=${CARGO:-cargo}
+
+cd "$(git rev-parse --show-toplevel)"
+
+echo "Checking benches/bench_main..."
+
+$CARGO nextest list --benches
+$CARGO nextest run --benches

--- a/src/benchmark_group.rs
+++ b/src/benchmark_group.rs
@@ -330,7 +330,7 @@ impl<'a, M: Measurement> BenchmarkGroup<'a, M> {
             }
             Mode::List => {
                 if do_run {
-                    println!("{}: bench", id);
+                    println!("{}: benchmark", id);
                 }
             }
             Mode::Test => {

--- a/src/benchmark_group.rs
+++ b/src/benchmark_group.rs
@@ -328,7 +328,7 @@ impl<'a, M: Measurement> BenchmarkGroup<'a, M> {
                     );
                 }
             }
-            Mode::List => {
+            Mode::List(_) => {
                 if do_run {
                     println!("{}: benchmark", id);
                 }
@@ -392,7 +392,7 @@ impl<'a, M: Measurement> Drop for BenchmarkGroup<'a, M> {
                 self.criterion.measurement.formatter(),
             );
         }
-        if self.any_matched {
+        if self.any_matched && !self.criterion.mode.is_terse() {
             self.criterion.report.group_separator();
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -899,10 +899,10 @@ https://bheisler.github.io/criterion.rs/book/faq.html
             (false, _) => true,     // cargo test --benches should run tests
         };
 
-        self.mode = if test_mode {
-            Mode::Test
-        } else if matches.is_present("list") {
+        self.mode = if matches.is_present("list") {
             Mode::List
+        } else if test_mode {
+            Mode::Test
         } else if matches.is_present("profile-time") {
             let num_seconds = matches.value_of_t_or_exit("profile-time");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -817,7 +817,7 @@ impl<M: Measurement> Criterion<M> {
                 .conflicts_with_all(&["test", "profile-time"]))
             .arg(Arg::new("format")
                 .long("format")
-                .possible_values(&["pretty", "terse"])
+                .possible_values(["pretty", "terse"])
                 .default_value("pretty")
                 // Note that libtest's --format also works during test execution, but criterion
                 // doesn't support that at the moment.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,8 +108,8 @@ static DEFAULT_PLOTTING_BACKEND: Lazy<PlottingBackend> = Lazy::new(|| match &*GN
     Ok(_) => PlottingBackend::Gnuplot,
     Err(e) => {
         match e {
-            VersionError::Exec(_) => println!("Gnuplot not found, using plotters backend"),
-            e => println!(
+            VersionError::Exec(_) => eprintln!("Gnuplot not found, using plotters backend"),
+            e => eprintln!(
                 "Gnuplot not found or not usable, using plotters backend\n{}",
                 e
             ),


### PR DESCRIPTION
This commit stack makes criterion compatible with nextest using the rules [listed here](https://nexte.st/book/custom-test-harnesses.html). Each commit is independently reviewable.

Note that none of these changes do anything special for nextest -- they just make criterion implement more of the libtest command-line interface, just enough to make nextest happy.

Addresses #562 -- once this commit stack lands and a new version of criterion goes out, I'd be happy to advertise compatibility on the nextest site.