### PR TITLE
Replace lazy_static dependency with once_cell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ license     = "Apache-2.0/MIT"
 exclude     = ["book/*"]
 
 [dependencies]
-lazy_static    = "1.4"
+once_cell      = "1.14"
 criterion-plot = { path = "plot", version = "0.4.5" }
 itertools      = "0.10"
 serde          = "1.0"


### PR DESCRIPTION
In modern Rust code, the macro-based API of lazy_static has been superseded by the non-macro API available in once_cell:

```diff
- lazy_static! {
-     static ref FOO: Type = init(…);
- }
+ static FOO: Lazy<Type> = Lazy::new(|| init(…));
```

- Avoiding a macro where not necessary makes this code formattable by rustfmt.

- The code becomes comprehensible to rustdoc, since it is just ordinary Rust code. Hint: in the red code above, the type of `FOO` is not actually `Type`. It is a weird/unexpected `struct FOO { _private: () }` whose API rustdoc won't be able to show the reader.

- The non-macro API matches what is slated for standardization in the standard library: https://doc.rust-lang.org/nightly/std/cell/struct.LazyCell.html.