### PR TITLE
Update docs: Make fn fibonacci() public in code example

### DIFF
--- a/book/src/getting_started.md
+++ b/book/src/getting_started.md
@@ -6,7 +6,7 @@ I'll assume that we have a crate, `mycrate`, whose `lib.rs` contains the followi
 
 ```rust
 #[inline]
-fn fibonacci(n: u64) -> u64 {
+pub fn fibonacci(n: u64) -> u64 {
     match n {
         0 => 1,
         1 => 1,


### PR DESCRIPTION
The current "Getting started" code example doesn't work. The `fn fibonacci()` must be public for the code to compile.