### PR TITLE
chore: replace atty with is-terminal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ serde          = "1.0"
 serde_json     = "1.0"
 serde_derive   = "1.0"
 ciborium       = "0.2.0"
-atty           = "0.2.6"
+is-terminal    = "0.4.6"
 clap           = { version = "3.1", default-features = false, features = ["std"] }
 walkdir        = "2.3"
 tinytemplate   = "1.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ extern crate approx;
 #[cfg(test)]
 extern crate quickcheck;
 
+use is_terminal::IsTerminal;
 use regex::Regex;
 
 #[cfg(feature = "real_blackbox")]
@@ -76,6 +77,7 @@ use std::cell::RefCell;
 use std::collections::HashSet;
 use std::default::Default;
 use std::env;
+use std::io::stdout;
 use std::net::TcpStream;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -1060,7 +1062,7 @@ https://bheisler.github.io/criterion.rs/book/faq.html
                     } else {
                         CliVerbosity::Normal
                     };
-                    let stdout_isatty = atty::is(atty::Stream::Stdout);
+                    let stdout_isatty = stdout().is_terminal();
                     let mut enable_text_overwrite = stdout_isatty && !verbose && !debug_enabled();
                     let enable_text_coloring;
                     match matches.value_of("color") {


### PR DESCRIPTION
`atty` is unmaintained and has a potential unaligned read. See https://github.com/rustsec/advisory-db/blob/main/crates/atty/RUSTSEC-2021-0145.md.

`is-terminal` is a replacement based on `atty`, with the soundness issue fixed and an (IMO) nicer to use API, mirroring what's available in the std lib on nightly with `std::io::IsTerminal`.
