### PR TITLE
Update criterion version in user-guide

### DIFF
--- a/book/src/getting_started.md
+++ b/book/src/getting_started.md
@@ -21,7 +21,7 @@ To enable Criterion.rs benchmarks, add the following to your `Cargo.toml` file:
 
 ```toml
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.4"
 
 [[bench]]
 name = "my_benchmark"


### PR DESCRIPTION
I haven't checked if the breaking changes of 0.4 impact the examples though