### PR TITLE
chore: wibbles to fix CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,7 @@ jobs:
         rust:
           - stable
           - 1.59 # MSRV
+          - nightly
 
     steps:
       - uses: actions/checkout@v3
@@ -72,6 +73,7 @@ jobs:
 
       - uses: actions-rs/cargo@v1
         name: Check for clippy hints
+        if: ${{ matrix.rust == 'stable' }}
         with:
           command: clippy
           args: -- -D warnings

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.57  # MSRV
+          - 1.59  # MSRV
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,11 +16,10 @@ jobs:
       matrix:
         rust:
           - stable
-          - beta
-          - 1.59  # MSRV
+          - 1.59 # MSRV
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions-rs/toolchain@v1
         name: Setup rust toolchain
@@ -30,7 +29,7 @@ jobs:
           override: true
           components: rustfmt, clippy
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         name: Load dependencies from cache
 
       - uses: actions-rs/cargo@v1

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -222,7 +222,7 @@ pub(crate) fn common<M: Measurement, T: ?Sized>(
     };
 
     let measurement_data = crate::report::MeasurementData {
-        data: Data::new(&*iters, &*times),
+        data: Data::new(&iters, &times),
         avg_times: labeled_sample,
         absolute_estimates: estimates,
         distributions,

--- a/src/csv_report.rs
+++ b/src/csv_report.rs
@@ -35,6 +35,7 @@ impl<W: Write> CsvReportWriter<W> {
         let value = id.value_str.as_deref();
         let (throughput_num, throughput_type) = match id.throughput {
             Some(Throughput::Bytes(bytes)) => (Some(format!("{}", bytes)), Some("bytes")),
+            Some(Throughput::BytesDecimal(bytes)) => (Some(format!("{}", bytes)), Some("bytes")),
             Some(Throughput::Elements(elems)) => (Some(format!("{}", elems)), Some("elements")),
             None => (None, None),
         };

--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -438,7 +438,7 @@ impl Report for Html {
 
         // If all of the value strings can be parsed into a number, sort/dedupe
         // numerically. Otherwise sort lexicographically.
-        if value_strs.iter().all(|os| try_parse(*os).is_some()) {
+        if value_strs.iter().all(|os| try_parse(os).is_some()) {
             value_strs.sort_unstable_by(|v1, v2| {
                 let num1 = try_parse(v1);
                 let num2 = try_parse(v2);
@@ -464,7 +464,7 @@ impl Report for Html {
 
                 self.generate_summary(
                     &subgroup_id,
-                    &*samples_with_function,
+                    &samples_with_function,
                     context,
                     formatter,
                     false,
@@ -483,13 +483,7 @@ impl Report for Html {
                 let subgroup_id =
                     BenchmarkId::new(group_id.clone(), None, Some(value_str.clone()), None);
 
-                self.generate_summary(
-                    &subgroup_id,
-                    &*samples_with_value,
-                    context,
-                    formatter,
-                    false,
-                );
+                self.generate_summary(&subgroup_id, &samples_with_value, context, formatter, false);
             }
         }
 
@@ -516,7 +510,7 @@ impl Report for Html {
 
         self.generate_summary(
             &BenchmarkId::new(group_id, None, None, None),
-            &*(all_data),
+            &all_data,
             context,
             formatter,
             true,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,8 +102,7 @@ pub use crate::bencher::Bencher;
 pub use crate::benchmark_group::{BenchmarkGroup, BenchmarkId};
 
 static DEBUG_ENABLED: Lazy<bool> = Lazy::new(|| std::env::var_os("CRITERION_DEBUG").is_some());
-static GNUPLOT_VERSION: Lazy<Result<Version, VersionError>> =
-    Lazy::new(|| criterion_plot::version());
+static GNUPLOT_VERSION: Lazy<Result<Version, VersionError>> = Lazy::new(criterion_plot::version);
 static DEFAULT_PLOTTING_BACKEND: Lazy<PlottingBackend> = Lazy::new(|| match &*GNUPLOT_VERSION {
     Ok(_) => PlottingBackend::Gnuplot,
     #[cfg(feature = "plotters")]
@@ -358,7 +357,7 @@ fn cargo_target_directory() -> Option<PathBuf> {
         .map(PathBuf::from)
         .or_else(|| {
             let output = Command::new(env::var_os("CARGO")?)
-                .args(&["metadata", "--format-version", "1"])
+                .args(["metadata", "--format-version", "1"])
                 .output()
                 .ok()?;
             let metadata: Metadata = serde_json::from_slice(&output.stdout).ok()?;
@@ -733,7 +732,7 @@ impl<M: Measurement> Criterion<M> {
                 .long("color")
                 .alias("colour")
                 .takes_value(true)
-                .possible_values(&["auto", "always", "never"])
+                .possible_values(["auto", "always", "never"])
                 .default_value("auto")
                 .help("Configure coloring of output. always = always colorize output, never = never colorize output, auto = colorize output if output is a tty and compiled for unix."))
             .arg(Arg::new("verbose")
@@ -826,12 +825,12 @@ impl<M: Measurement> Criterion<M> {
             .arg(Arg::new("plotting-backend")
                  .long("plotting-backend")
                  .takes_value(true)
-                 .possible_values(&["gnuplot", "plotters"])
+                 .possible_values(["gnuplot", "plotters"])
                  .help("Set the plotting backend. By default, Criterion.rs will use the gnuplot backend if gnuplot is available, or the plotters backend if it isn't."))
             .arg(Arg::new("output-format")
                 .long("output-format")
                 .takes_value(true)
-                .possible_values(&["criterion", "bencher"])
+                .possible_values(["criterion", "bencher"])
                 .default_value("criterion")
                 .help("Change the CLI output format. By default, Criterion.rs will use its own format. If output format is set to 'bencher', Criterion.rs will print output in a format that resembles the 'bencher' crate."))
             .arg(Arg::new("nocapture")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,7 @@ static GNUPLOT_VERSION: Lazy<Result<Version, VersionError>> =
     Lazy::new(|| criterion_plot::version());
 static DEFAULT_PLOTTING_BACKEND: Lazy<PlottingBackend> = Lazy::new(|| match &*GNUPLOT_VERSION {
     Ok(_) => PlottingBackend::Gnuplot,
+    #[cfg(feature = "plotters")]
     Err(e) => {
         match e {
             VersionError::Exec(_) => println!("Gnuplot not found, using plotters backend"),
@@ -116,6 +117,8 @@ static DEFAULT_PLOTTING_BACKEND: Lazy<PlottingBackend> = Lazy::new(|| match &*GN
         };
         PlottingBackend::Plotters
     }
+    #[cfg(not(feature = "plotters"))]
+    Err(_) => PlottingBackend::None,
 });
 static CARGO_CRITERION_CONNECTION: Lazy<Option<Mutex<Connection>>> =
     Lazy::new(|| match std::env::var("CARGO_CRITERION_PORT") {

--- a/src/plot/gnuplot_backend/summary.rs
+++ b/src/plot/gnuplot_backend/summary.rs
@@ -130,7 +130,7 @@ pub fn violin(
 ) -> Child {
     let path = PathBuf::from(&path);
     let all_curves_vec = all_curves.iter().rev().cloned().collect::<Vec<_>>();
-    let all_curves: &[&(&BenchmarkId, Vec<f64>)] = &*all_curves_vec;
+    let all_curves: &[&(&BenchmarkId, Vec<f64>)] = &all_curves_vec;
 
     let kdes = all_curves
         .iter()

--- a/src/plot/plotters_backend/distributions.rs
+++ b/src/plot/plotters_backend/distributions.rs
@@ -85,11 +85,11 @@ fn abs_distribution(
     chart
         .draw_series(LineSeries::new(
             kde_xs.iter().zip(ys.iter()).map(|(&x, &y)| (x, y)),
-            &DARK_BLUE,
+            DARK_BLUE,
         ))
         .unwrap()
         .label("Bootstrap distribution")
-        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], &DARK_BLUE));
+        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], DARK_BLUE));
 
     chart
         .draw_series(AreaSeries::new(
@@ -115,7 +115,7 @@ fn abs_distribution(
         )))
         .unwrap()
         .label("Point estimate")
-        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], &DARK_BLUE));
+        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], DARK_BLUE));
 
     chart
         .configure_series_labels()
@@ -240,11 +240,11 @@ fn rel_distribution(
     chart
         .draw_series(LineSeries::new(
             xs.iter().zip(ys.iter()).map(|(x, y)| (*x, *y)),
-            &DARK_BLUE,
+            DARK_BLUE,
         ))
         .unwrap()
         .label("Bootstrap distribution")
-        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], &DARK_BLUE));
+        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], DARK_BLUE));
 
     chart
         .draw_series(AreaSeries::new(
@@ -269,7 +269,7 @@ fn rel_distribution(
         )))
         .unwrap()
         .label("Point estimate")
-        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], &DARK_BLUE));
+        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], DARK_BLUE));
 
     chart
         .draw_series(std::iter::once(Rectangle::new(

--- a/src/plot/plotters_backend/iteration_times.rs
+++ b/src/plot/plotters_backend/iteration_times.rs
@@ -37,7 +37,7 @@ pub(crate) fn iteration_times_figure(
         .configure_mesh()
         .y_desc(format!("Average Iteration Time ({})", unit))
         .x_label_formatter(&|x| pretty_print_float(*x, true))
-        .light_line_style(&TRANSPARENT)
+        .light_line_style(TRANSPARENT)
         .draw()
         .unwrap();
 
@@ -104,7 +104,7 @@ pub(crate) fn iteration_times_comparison_figure(
         .configure_mesh()
         .y_desc(format!("Average Iteration Time ({})", unit))
         .x_label_formatter(&|x| pretty_print_float(*x, true))
-        .light_line_style(&TRANSPARENT)
+        .light_line_style(TRANSPARENT)
         .draw()
         .unwrap();
 

--- a/src/plot/plotters_backend/pdf.rs
+++ b/src/plot/plotters_backend/pdf.rs
@@ -93,7 +93,7 @@ pub(crate) fn pdf_comparison_figure(
         )))
         .unwrap()
         .label("Base Mean")
-        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], &DARK_RED));
+        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], DARK_RED));
 
     chart
         .draw_series(std::iter::once(PathElement::new(
@@ -102,7 +102,7 @@ pub(crate) fn pdf_comparison_figure(
         )))
         .unwrap()
         .label("New Mean")
-        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], &DARK_BLUE));
+        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], DARK_BLUE));
 
     if title.is_some() {
         chart.configure_series_labels().draw().unwrap();
@@ -255,18 +255,18 @@ pub(crate) fn pdf(
     chart
         .draw_series(std::iter::once(PathElement::new(
             vec![(mean, 0.0), (mean, max_iters)],
-            &DARK_BLUE,
+            DARK_BLUE,
         )))
         .unwrap()
         .label("Mean")
-        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], &DARK_BLUE));
+        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], DARK_BLUE));
 
     chart
         .draw_series(vec![
-            PathElement::new(vec![(lomt, 0.0), (lomt, max_iters)], &DARK_ORANGE),
-            PathElement::new(vec![(himt, 0.0), (himt, max_iters)], &DARK_ORANGE),
-            PathElement::new(vec![(lost, 0.0), (lost, max_iters)], &DARK_RED),
-            PathElement::new(vec![(hist, 0.0), (hist, max_iters)], &DARK_RED),
+            PathElement::new(vec![(lomt, 0.0), (lomt, max_iters)], DARK_ORANGE),
+            PathElement::new(vec![(himt, 0.0), (himt, max_iters)], DARK_ORANGE),
+            PathElement::new(vec![(lost, 0.0), (lost, max_iters)], DARK_RED),
+            PathElement::new(vec![(hist, 0.0), (hist, max_iters)], DARK_RED),
         ])
         .unwrap();
     use crate::stats::univariate::outliers::tukey::Label;

--- a/src/plot/plotters_backend/regression.rs
+++ b/src/plot/plotters_backend/regression.rs
@@ -61,7 +61,7 @@ pub(crate) fn regression_figure(
         .x_desc(x_label)
         .y_desc(format!("Total sample time ({})", unit))
         .x_label_formatter(&|x| pretty_print_float(x * x_scale, true))
-        .light_line_style(&TRANSPARENT)
+        .light_line_style(TRANSPARENT)
         .draw()
         .unwrap();
 
@@ -79,7 +79,7 @@ pub(crate) fn regression_figure(
     chart
         .draw_series(std::iter::once(PathElement::new(
             vec![(0.0, 0.0), (max_iters, point)],
-            &DARK_BLUE,
+            DARK_BLUE,
         )))
         .unwrap()
         .label("Linear regression")
@@ -187,13 +187,13 @@ pub(crate) fn regression_comparison_figure(
         .x_desc(x_label)
         .y_desc(format!("Total sample time ({})", unit))
         .x_label_formatter(&|x| pretty_print_float(x * x_scale, true))
-        .light_line_style(&TRANSPARENT)
+        .light_line_style(TRANSPARENT)
         .draw()
         .unwrap();
 
     chart
         .draw_series(vec![
-            PathElement::new(vec![(0.0, 0.0), (max_iters, base_point)], &DARK_RED).into_dyn(),
+            PathElement::new(vec![(0.0, 0.0), (max_iters, base_point)], DARK_RED).into_dyn(),
             Polygon::new(
                 vec![(0.0, 0.0), (max_iters, base_lb), (max_iters, base_ub)],
                 DARK_RED.mix(0.25).filled(),
@@ -208,7 +208,7 @@ pub(crate) fn regression_comparison_figure(
 
     chart
         .draw_series(vec![
-            PathElement::new(vec![(0.0, 0.0), (max_iters, point)], &DARK_BLUE).into_dyn(),
+            PathElement::new(vec![(0.0, 0.0), (max_iters, point)], DARK_BLUE).into_dyn(),
             Polygon::new(
                 vec![(0.0, 0.0), (max_iters, lb), (max_iters, ub)],
                 DARK_BLUE.mix(0.25).filled(),

--- a/src/plot/plotters_backend/summary.rs
+++ b/src/plot/plotters_backend/summary.rs
@@ -159,7 +159,7 @@ pub fn violin(
     axis_scale: AxisScale,
 ) {
     let all_curves_vec = all_curves.iter().rev().cloned().collect::<Vec<_>>();
-    let all_curves: &[&(&BenchmarkId, Vec<f64>)] = &*all_curves_vec;
+    let all_curves: &[&(&BenchmarkId, Vec<f64>)] = &all_curves_vec;
 
     let mut kdes = all_curves
         .iter()
@@ -250,7 +250,7 @@ fn draw_violin_figure<XR: AsRangedCoord<Value = f64>, YR: AsRangedCoord<Value = 
             .draw_series(AreaSeries::new(
                 x.iter().zip(y.iter()).map(|(x, y)| (*x, base + *y / 2.0)),
                 base,
-                &DARK_BLUE,
+                DARK_BLUE,
             ))
             .unwrap();
 
@@ -258,7 +258,7 @@ fn draw_violin_figure<XR: AsRangedCoord<Value = f64>, YR: AsRangedCoord<Value = 
             .draw_series(AreaSeries::new(
                 x.iter().zip(y.iter()).map(|(x, y)| (*x, base - *y / 2.0)),
                 base,
-                &DARK_BLUE,
+                DARK_BLUE,
             ))
             .unwrap();
     }

--- a/src/plot/plotters_backend/t_test.rs
+++ b/src/plot/plotters_backend/t_test.rs
@@ -38,7 +38,7 @@ pub(crate) fn t_test(
         .draw_series(AreaSeries::new(
             xs.iter().zip(ys.iter()).map(|(x, y)| (*x, *y)),
             0.0,
-            &DARK_BLUE.mix(0.25),
+            DARK_BLUE.mix(0.25),
         ))
         .unwrap()
         .label("t distribution")
@@ -53,7 +53,7 @@ pub(crate) fn t_test(
         )))
         .unwrap()
         .label("t statistic")
-        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], &DARK_BLUE));
+        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], DARK_BLUE));
 
     chart.configure_series_labels().draw().unwrap();
 }


### PR DESCRIPTION
- Bump CI rustc version to 1.59 (matching the MSRV).
- Deal with `Throughput::BytesDecimal` in the CSV backend.
- Default to no plotting if gnuplot and plotters are unavailable.
- Disable testing on 'beta'.
- Fix clippy suggestions.
- Enable testing on `nightly`.