### PR TITLE
Changes the license field to valid SPDX

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository  = "https://github.com/bheisler/criterion.rs"
 readme      = "README.md"
 keywords    = ["criterion", "benchmark"]
 categories  = ["development-tools::profiling"]
-license     = "Apache-2.0/MIT"
+license     = "Apache-2.0 OR MIT"
 exclude     = ["book/*"]
 
 [dependencies]

--- a/plot/Cargo.toml
+++ b/plot/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/bheisler/criterion.rs"
 readme = "README.md"
 keywords = ["plotting", "gnuplot", "criterion"]
 categories = ["visualization"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 cast = "0.3"


### PR DESCRIPTION
This change fixes the license field to valid SPDX. 
[Documentation](https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields) says that SPDX license expressions support AND and OR operators to combine multiple licenses. Previously multiple licenses could be separated with a /, but that usage is deprecated.

It is currently causing dependency reviews to fail like:
<img width="1004" alt="Dependency" src="https://user-images.githubusercontent.com/4755196/214824776-aa434d21-81f6-4469-9b6c-3c33579d408f.png">
