### PR TITLE
Adds ability to plot throughput on summary page.

### DIFF
--- a/src/html/summary_report.html.tt
+++ b/src/html/summary_report.html.tt
@@ -66,6 +66,11 @@
         <img src="lines.svg" alt="Line Chart" />
         <p>This chart shows the mean measured time for each function as the input (or the size of the input) increases.</p>
         {{- endif }}
+        {{- if line_throughput_chart }}
+        <h3>Throughput Chart</h3>
+        <img src="lines_throughput.svg" alt="Line Chart" />
+        <p>This chart shows the mean measured throughput for each function as the input (or the size of the input) increases.</p>
+        {{- endif }}
         {{- for bench in benchmarks }}
         <section class="plots">
             <a href="{bench.path}/report/index.html">

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1168,7 +1168,7 @@ https://bheisler.github.io/criterion.rs/book/faq.html
     ///     // Now we can perform benchmarks with this group
     ///     group.bench_function("Bench 1", |b| b.iter(|| 1 ));
     ///     group.bench_function("Bench 2", |b| b.iter(|| 2 ));
-    ///    
+    ///
     ///     group.finish();
     /// }
     /// criterion_group!(benches, bench_simple);

--- a/src/plot/gnuplot_backend/mod.rs
+++ b/src/plot/gnuplot_backend/mod.rs
@@ -22,7 +22,7 @@ use crate::measurement::ValueFormatter;
 use crate::report::{BenchmarkId, ValueType};
 use crate::stats::bivariate::Data;
 
-use super::{PlotContext, PlotData, Plotter};
+use super::{LinePlotConfig, PlotContext, PlotData, Plotter};
 use crate::format;
 
 fn gnuplot_escape(string: &str) -> String {
@@ -201,13 +201,15 @@ impl Plotter for Gnuplot {
 
     fn line_comparison(
         &mut self,
+        line_config: LinePlotConfig,
         ctx: PlotContext<'_>,
         formatter: &dyn ValueFormatter,
         all_curves: &[&(&BenchmarkId, Vec<f64>)],
         value_type: ValueType,
     ) {
-        let path = ctx.line_comparison_path();
+        let path = (line_config.path)(&ctx);
         self.process_list.push(line_comparison(
+            line_config,
             formatter,
             ctx.id.as_title(),
             all_curves,

--- a/src/plot/plotters_backend/mod.rs
+++ b/src/plot/plotters_backend/mod.rs
@@ -1,4 +1,4 @@
-use super::{PlotContext, PlotData, Plotter};
+use super::{LinePlotConfig, PlotContext, PlotData, Plotter};
 use crate::measurement::ValueFormatter;
 use crate::report::{BenchmarkId, ComparisonData, MeasurementData, ValueType};
 use plotters::data::float::pretty_print_float;
@@ -184,13 +184,15 @@ impl Plotter for PlottersBackend {
 
     fn line_comparison(
         &mut self,
+        line_config: LinePlotConfig,
         ctx: PlotContext<'_>,
         formatter: &dyn ValueFormatter,
         all_curves: &[&(&BenchmarkId, Vec<f64>)],
         value_type: ValueType,
     ) {
-        let path = ctx.line_comparison_path();
+        let path = (line_config.path)(&ctx);
         summary::line_comparison(
+            line_config,
             formatter,
             ctx.id.as_title(),
             all_curves,


### PR DESCRIPTION
Fixes https://github.com/bheisler/cargo-criterion/issues/9.

This was originally based on https://github.com/bheisler/criterion.rs/pull/315. I ported it to latest version, including support for the plotters backend. Both time and throughput charts are very similar, thus I decided to go additional arguments to `Plotter::line_comparison` function rather than a separate one.

Most notably, added `LinePlotConfig` type which configures whether `line_comparison` plots time or throughput. I had to employ a slightly dirty hack in throughput's `LinePlotConfig` scaling function, to make throughput scale consistent across the plot. It could have been possible to make it cleaner with modifications to `ValueFormatter`, but I decided against breaking public API.