### PR TITLE
Remove unnecessary `pub` from example code

### DIFF
--- a/book/src/getting_started.md
+++ b/book/src/getting_started.md
@@ -42,7 +42,7 @@ below for an explanation of this code):
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use mycrate::fibonacci;
 
-pub fn criterion_benchmark(c: &mut Criterion) {
+fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("fib 20", |b| b.iter(|| fibonacci(black_box(20))));
 }
 


### PR DESCRIPTION
Using `pub` is not necessary for the benchmark functions and prevents the compiler from detecting unused benchmark functions.