### PR TITLE
Fix bug where time over the maximum would be reported as 1ms in quick mode

### DIFF
--- a/src/routine.rs
+++ b/src/routine.rs
@@ -102,7 +102,6 @@ pub(crate) trait Routine<M: Measurement, T: ?Sized> {
 
             // Early exit for extremely long running benchmarks:
             if time_start.elapsed() > maximum_bench_duration {
-                let t_prev = 1_000_000f64;
                 let iters = vec![n as f64, n as f64].into_boxed_slice();
                 let elapsed = vec![t_prev, t_prev].into_boxed_slice();
                 return (ActualSamplingMode::Flat, iters, elapsed);


### PR DESCRIPTION
See issue https://github.com/bheisler/criterion.rs/issues/658.
See also the minimal working example at <https://github.com/KonradHoeffner/criterion-quick-bug>.
This will report the correct time of the first and only iteration in quick mode.
Note that it will still crash with plotting due to the values being the same, so `cargo bench -- --quick --noplot` must be used.