### PR TITLE
Improve documentation regarding the html reports feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ To start with Criterion.<span></span>rs, add the following to your `Cargo.toml` 
 
 ```toml
 [dev-dependencies]
-criterion = "0.4"
+criterion = { version = "0.4", features = ["html_reports"] }
 
 [[bench]]
 name = "my_benchmark"
@@ -107,7 +107,7 @@ First, thank you for contributing.
 One great way to contribute to Criterion.<span></span>rs is to use it for your own benchmarking needs and report your experiences, file and comment on issues, etc.
 
 Code or documentation improvements in the form of pull requests are also welcome. If you're not
-sure what to work on, try checking the 
+sure what to work on, try checking the
 [Beginner label](https://github.com/bheisler/criterion.rs/issues?q=is%3Aissue+is%3Aopen+label%3ABeginner).
 
 If your issues or pull requests have no response after a few days, feel free to ping me (@bheisler).

--- a/book/src/user_guide/plots_and_graphs.md
+++ b/book/src/user_guide/plots_and_graphs.md
@@ -6,6 +6,14 @@ understanding of the behavior of the benchmark. These charts will be generated w
 it is not available. The examples below were generated using the gnuplot backend, but the plotters
 ones are similar.
 
+Note that in older versions of criterion.rs html reports were enabled by default. Recent versions
+have introduced a cargo feature for plot and html generation. In order to activate the html report
+generation make sure that your `Cargo.toml` activates the feature:
+
+```toml
+criterion = { version = "0.4", features = ["html_reports"] }
+```
+
 ## File Structure
 
 The plots and saved data are stored under `target/criterion/$BENCHMARK_NAME/`. Here's an example of


### PR DESCRIPTION
The fact that the html report generation has been moved into a cargo feature seem to confuse quite a lot of people. It came of frequently recently:

- Closes https://github.com/bheisler/criterion.rs/issues/638
- Closes https://github.com/bheisler/criterion.rs/issues/652
- https://github.com/bheisler/criterion.rs/issues/632
- https://github.com/bheisler/criterion.rs/issues/660
- And on [StackOverflow](https://stackoverflow.com/questions/65831274/where-is-criterions-output-or-how-do-i-enable-it)

I think this is simply because it isn't mentioned in the docs prominently enough (actually, I don't think it is mentioned at all). This PR should help to avoid running people falling into the same trap.