### PR TITLE
Mark black_box function as unsafe

### DIFF
--- a/src/bencher.rs
+++ b/src/bencher.rs
@@ -246,14 +246,14 @@ impl<'a, M: Measurement> Bencher<'a, M> {
 
         if batch_size == 1 {
             for _ in 0..self.iters {
-                let input = black_box(setup());
+                let input = unsafe { black_box(setup()) };
 
                 let start = self.measurement.start();
                 let output = routine(input);
                 let end = self.measurement.end(start);
                 self.value = self.measurement.add(&self.value, &end);
 
-                drop(black_box(output));
+                drop(unsafe { black_box(output) });
             }
         } else {
             let mut iteration_counter = 0;
@@ -261,7 +261,7 @@ impl<'a, M: Measurement> Bencher<'a, M> {
             while iteration_counter < self.iters {
                 let batch_size = ::std::cmp::min(batch_size, self.iters - iteration_counter);
 
-                let inputs = black_box((0..batch_size).map(|_| setup()).collect::<Vec<_>>());
+                let inputs = unsafe { black_box((0..batch_size).map(|_| setup()).collect::<Vec<_>>()) };
                 let mut outputs = Vec::with_capacity(batch_size as usize);
 
                 let start = self.measurement.start();
@@ -269,7 +269,7 @@ impl<'a, M: Measurement> Bencher<'a, M> {
                 let end = self.measurement.end(start);
                 self.value = self.measurement.add(&self.value, &end);
 
-                black_box(outputs);
+                unsafe { black_box(outputs) };
 
                 iteration_counter += batch_size;
             }
@@ -336,15 +336,15 @@ impl<'a, M: Measurement> Bencher<'a, M> {
 
         if batch_size == 1 {
             for _ in 0..self.iters {
-                let mut input = black_box(setup());
+                let mut input = unsafe { black_box(setup()) };
 
                 let start = self.measurement.start();
                 let output = routine(&mut input);
                 let end = self.measurement.end(start);
                 self.value = self.measurement.add(&self.value, &end);
 
-                drop(black_box(output));
-                drop(black_box(input));
+                drop(unsafe { black_box(output) });
+                drop(unsafe { black_box(input) });
             }
         } else {
             let mut iteration_counter = 0;
@@ -352,7 +352,7 @@ impl<'a, M: Measurement> Bencher<'a, M> {
             while iteration_counter < self.iters {
                 let batch_size = ::std::cmp::min(batch_size, self.iters - iteration_counter);
 
-                let mut inputs = black_box((0..batch_size).map(|_| setup()).collect::<Vec<_>>());
+                let mut inputs = unsafe { black_box((0..batch_size).map(|_| setup()).collect::<Vec<_>>()) };
                 let mut outputs = Vec::with_capacity(batch_size as usize);
 
                 let start = self.measurement.start();
@@ -360,7 +360,7 @@ impl<'a, M: Measurement> Bencher<'a, M> {
                 let end = self.measurement.end(start);
                 self.value = self.measurement.add(&self.value, &end);
 
-                black_box(outputs);
+                unsafe { black_box(outputs) };
 
                 iteration_counter += batch_size;
             }

--- a/src/bencher.rs
+++ b/src/bencher.rs
@@ -85,7 +85,7 @@ impl<'a, M: Measurement> Bencher<'a, M> {
         let time_start = Instant::now();
         let start = self.measurement.start();
         for _ in 0..self.iters {
-            black_box(routine());
+            unsafe { black_box(routine()) };
         }
         self.value = self.measurement.end(start);
         self.elapsed_time = time_start.elapsed();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,12 +162,10 @@ pub fn black_box<T>(dummy: T) -> T {
 /// This variant is stable-compatible, but it may cause some performance overhead
 /// or fail to prevent code from being eliminated.
 #[cfg(not(feature = "real_blackbox"))]
-pub fn black_box<T>(dummy: T) -> T {
-    unsafe {
+pub unsafe fn black_box<T>(dummy: T) -> T {
         let ret = std::ptr::read_volatile(&dummy);
         std::mem::forget(dummy);
         ret
-    }
 }
 
 /// Argument to [`Bencher::iter_batched`](struct.Bencher.html#method.iter_batched) and

--- a/src/routine.rs
+++ b/src/routine.rs
@@ -266,7 +266,7 @@ where
         let mut total_iters = 0;
         let mut elapsed_time = Duration::from_millis(0);
         loop {
-            (*f)(&mut b, black_box(parameter));
+            (*f)(&mut b, unsafe { black_box(parameter) });
 
             b.assert_iterated();
 

--- a/src/routine.rs
+++ b/src/routine.rs
@@ -246,7 +246,7 @@ where
             .iter()
             .map(|iters| {
                 b.iters = *iters;
-                (*f)(&mut b, black_box(parameter));
+                (*f)(&mut b, unsafe { black_box(parameter) });
                 b.assert_iterated();
                 m.to_f64(&b.value)
             })


### PR DESCRIPTION
Hello, I found a soundness issue in this crate.
https://github.com/bheisler/criterion.rs/blob/2f5360737807cbe90d149db6199783236f0ef634/src/lib.rs#L165-L171
[https://doc.rust-lang.org/std/ptr/fn.read_volatile.html](url)
The unsafe function called needs to ensure that the parameter must be:

- src must be valid for reads.
- src must be properly aligned.
- src must point to a properly initialized value of type T.

and it is not a good choice to mark the entire function body as unsafe, which will make the caller ignore the safety requirements that the function parameters must guarantee, the developer who calls the black_box function may not notice this safety requirement.
Marking them unsafe also means that callers must make sure they know what they're doing.
