### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -537,8 +537,8 @@ impl Report for Html {
         }
 
         let mut groups = id_groups
-            .into_iter()
-            .map(|(_, group)| BenchmarkGroup::new(output_directory, &group))
+            .into_values()
+            .map(|group| BenchmarkGroup::new(output_directory, &group))
             .collect::<Vec<BenchmarkGroup<'_>>>();
         groups.sort_unstable_by_key(|g| g.group_report.name);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1432,7 +1432,7 @@ impl ActualSamplingMode {
                     }
                 }
 
-                (1..(n + 1) as u64).map(|a| a * d).collect::<Vec<u64>>()
+                (1..(n + 1)).map(|a| a * d).collect::<Vec<u64>>()
             }
             ActualSamplingMode::Flat => {
                 let n = sample_count;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,9 +287,9 @@ pub enum PlottingBackend {
 impl PlottingBackend {
     fn create_plotter(&self) -> Option<Box<dyn Plotter>> {
         match self {
-            PlottingBackend::Gnuplot => Some(Box::new(Gnuplot::default())),
+            PlottingBackend::Gnuplot => Some(Box::<Gnuplot>::default()),
             #[cfg(feature = "plotters")]
-            PlottingBackend::Plotters => Some(Box::new(PlottersBackend::default())),
+            PlottingBackend::Plotters => Some(Box::<PlottersBackend>::default()),
             #[cfg(not(feature = "plotters"))]
             PlottingBackend::Plotters => panic!("Criterion was built without plotters support."),
             PlottingBackend::None => None,

--- a/src/plot/gnuplot_backend/summary.rs
+++ b/src/plot/gnuplot_backend/summary.rs
@@ -67,7 +67,7 @@ pub fn line_comparison(
 
     let max = all_curves
         .iter()
-        .map(|&&(_, ref data)| Sample::new(data).mean())
+        .map(|&(_, data)| Sample::new(data).mean())
         .fold(::std::f64::NAN, f64::max);
 
     let mut dummy = [1.0];
@@ -134,7 +134,7 @@ pub fn violin(
 
     let kdes = all_curves
         .iter()
-        .map(|&&(_, ref sample)| {
+        .map(|&(_, sample)| {
             let (x, mut y) = kde::sweep(Sample::new(sample), KDE_POINTS, None);
             let y_max = Sample::new(&y).max();
             for y in y.iter_mut() {
@@ -144,10 +144,7 @@ pub fn violin(
             (x, y)
         })
         .collect::<Vec<_>>();
-    let mut xs = kdes
-        .iter()
-        .flat_map(|&(ref x, _)| x.iter())
-        .filter(|&&x| x > 0.);
+    let mut xs = kdes.iter().flat_map(|(x, _)| x.iter()).filter(|&&x| x > 0.);
     let (mut min, mut max) = {
         let &first = xs.next().unwrap();
         (first, first)
@@ -190,7 +187,7 @@ pub fn violin(
         });
 
     let mut is_first = true;
-    for (i, &(ref x, ref y)) in kdes.iter().enumerate() {
+    for (i, (x, y)) in kdes.iter().enumerate() {
         let i = i as f64 + 0.5;
         let y1: Vec<_> = y.iter().map(|&y| i + y * 0.45).collect();
         let y2: Vec<_> = y.iter().map(|&y| i - y * 0.45).collect();

--- a/src/plot/gnuplot_backend/summary.rs
+++ b/src/plot/gnuplot_backend/summary.rs
@@ -171,7 +171,7 @@ pub fn violin(
         .configure(Axis::BottomX, |a| {
             a.configure(Grid::Major, |g| g.show())
                 .configure(Grid::Minor, |g| g.hide())
-                .set(Range::Limits(0., max as f64 * one[0]))
+                .set(Range::Limits(0., max * one[0]))
                 .set(Label(format!("Average time ({})", unit)))
                 .set(axis_scale.to_gnuplot())
         })

--- a/src/plot/plotters_backend/pdf.rs
+++ b/src/plot/plotters_backend/pdf.rs
@@ -38,7 +38,7 @@ pub(crate) fn pdf_comparison_figure(
     let y_range = data::fitting_range(base_ys.iter().chain(ys.iter()));
 
     let size = size.unwrap_or(SIZE);
-    let root_area = SVGBackend::new(&path, (size.0 as u32, size.1 as u32)).into_drawing_area();
+    let root_area = SVGBackend::new(&path, size).into_drawing_area();
 
     let mut cb = ChartBuilder::on(&root_area);
 
@@ -132,7 +132,7 @@ pub(crate) fn pdf_small(
     let path = context.report_path(id, "pdf_small.svg");
 
     let size = size.unwrap_or(SIZE);
-    let root_area = SVGBackend::new(&path, (size.0 as u32, size.1 as u32)).into_drawing_area();
+    let root_area = SVGBackend::new(&path, size).into_drawing_area();
 
     let mut chart = ChartBuilder::on(&root_area)
         .margin((5).percent())
@@ -208,7 +208,7 @@ pub(crate) fn pdf(
     let xs_ = Sample::new(&xs);
 
     let size = size.unwrap_or(SIZE);
-    let root_area = SVGBackend::new(&path, (size.0 as u32, size.1 as u32)).into_drawing_area();
+    let root_area = SVGBackend::new(&path, size).into_drawing_area();
 
     let range = data::fitting_range(ys.iter());
 

--- a/src/plot/plotters_backend/summary.rs
+++ b/src/plot/plotters_backend/summary.rs
@@ -120,7 +120,7 @@ fn line_comparison_series_data<'a>(
 ) -> (&'static str, Vec<(Option<&'a String>, Vec<f64>, Vec<f64>)>) {
     let max = all_curves
         .iter()
-        .map(|&&(_, ref data)| Sample::new(data).mean())
+        .map(|&(_, data)| Sample::new(data).mean())
         .fold(::std::f64::NAN, f64::max);
 
     let mut dummy = [1.0];
@@ -176,7 +176,7 @@ pub fn violin(
 
     let mut xs = kdes
         .iter()
-        .flat_map(|&(_, ref x, _)| x.iter())
+        .flat_map(|(_, x, _)| x.iter())
         .filter(|&&x| x > 0.);
     let (mut min, mut max) = {
         let &first = xs.next().unwrap();

--- a/src/report.rs
+++ b/src/report.rs
@@ -116,10 +116,10 @@ impl BenchmarkId {
         throughput: Option<Throughput>,
     ) -> BenchmarkId {
         let full_id = match (&function_id, &value_str) {
-            (&Some(ref func), &Some(ref val)) => format!("{}/{}/{}", group_id, func, val),
-            (&Some(ref func), &None) => format!("{}/{}", group_id, func),
-            (&None, &Some(ref val)) => format!("{}/{}", group_id, val),
-            (&None, &None) => group_id.clone(),
+            (Some(func), Some(val)) => format!("{}/{}/{}", group_id, func, val),
+            (Some(func), None) => format!("{}/{}", group_id, func),
+            (None, Some(val)) => format!("{}/{}", group_id, val),
+            (None, None) => group_id.clone(),
         };
 
         let mut title = full_id.clone();
@@ -129,23 +129,23 @@ impl BenchmarkId {
         }
 
         let directory_name = match (&function_id, &value_str) {
-            (&Some(ref func), &Some(ref val)) => format!(
+            (Some(func), Some(val)) => format!(
                 "{}/{}/{}",
                 make_filename_safe(&group_id),
                 make_filename_safe(func),
                 make_filename_safe(val)
             ),
-            (&Some(ref func), &None) => format!(
+            (Some(func), None) => format!(
                 "{}/{}",
                 make_filename_safe(&group_id),
                 make_filename_safe(func)
             ),
-            (&None, &Some(ref val)) => format!(
+            (None, Some(val)) => format!(
                 "{}/{}",
                 make_filename_safe(&group_id),
                 make_filename_safe(val)
             ),
-            (&None, &None) => make_filename_safe(&group_id),
+            (None, None) => make_filename_safe(&group_id),
         };
 
         BenchmarkId {

--- a/tests/criterion_tests.rs
+++ b/tests/criterion_tests.rs
@@ -1,6 +1,3 @@
-use criterion;
-use serde_json;
-
 #[cfg(feature = "plotters")]
 use criterion::SamplingMode;
 use criterion::{
@@ -469,7 +466,7 @@ fn test_criterion_doesnt_panic_if_measured_time_is_zero() {
 }
 
 mod macros {
-    use super::{criterion, criterion_group, criterion_main};
+    use super::{criterion_group, criterion_main};
 
     #[test]
     #[should_panic(expected = "group executed")]
@@ -504,7 +501,7 @@ mod macros {
     #[test]
     #[should_panic(expected = "group executed")]
     fn criterion_group() {
-        use self::criterion::Criterion;
+        use criterion::Criterion;
 
         fn group(_crit: &mut Criterion) {}
         fn group2(_crit: &mut Criterion) {
@@ -519,7 +516,7 @@ mod macros {
     #[test]
     #[should_panic(expected = "group executed")]
     fn criterion_group_trailing_comma() {
-        use self::criterion::Criterion;
+        use criterion::Criterion;
 
         fn group(_crit: &mut Criterion) {}
         fn group2(_crit: &mut Criterion) {

--- a/tests/criterion_tests.rs
+++ b/tests/criterion_tests.rs
@@ -81,12 +81,12 @@ fn verify_html(dir: &PathBuf, path: &str) {
 }
 
 fn verify_stats(dir: &PathBuf, baseline: &str) {
-    verify_json(&dir, &format!("{}/estimates.json", baseline));
-    verify_json(&dir, &format!("{}/sample.json", baseline));
-    verify_json(&dir, &format!("{}/tukey.json", baseline));
-    verify_json(&dir, &format!("{}/benchmark.json", baseline));
+    verify_json(dir, &format!("{}/estimates.json", baseline));
+    verify_json(dir, &format!("{}/sample.json", baseline));
+    verify_json(dir, &format!("{}/tukey.json", baseline));
+    verify_json(dir, &format!("{}/benchmark.json", baseline));
     #[cfg(feature = "csv_output")]
-    verify_file(&dir, &format!("{}/raw.csv", baseline));
+    verify_file(dir, &format!("{}/raw.csv", baseline));
 }
 
 fn verify_not_exists(dir: &PathBuf, path: &str) {

--- a/tests/criterion_tests.rs
+++ b/tests/criterion_tests.rs
@@ -52,7 +52,7 @@ impl Default for Counter {
     }
 }
 
-fn verify_file(dir: &PathBuf, path: &str) -> PathBuf {
+fn verify_file(dir: &Path, path: &str) -> PathBuf {
     let full_path = dir.join(path);
     assert!(
         full_path.is_file(),
@@ -64,23 +64,23 @@ fn verify_file(dir: &PathBuf, path: &str) -> PathBuf {
     full_path
 }
 
-fn verify_json(dir: &PathBuf, path: &str) {
+fn verify_json(dir: &Path, path: &str) {
     let full_path = verify_file(dir, path);
     let f = File::open(full_path).unwrap();
     serde_json::from_reader::<File, Value>(f).unwrap();
 }
 
 #[cfg(feature = "html_reports")]
-fn verify_svg(dir: &PathBuf, path: &str) {
+fn verify_svg(dir: &Path, path: &str) {
     verify_file(dir, path);
 }
 
 #[cfg(feature = "html_reports")]
-fn verify_html(dir: &PathBuf, path: &str) {
+fn verify_html(dir: &Path, path: &str) {
     verify_file(dir, path);
 }
 
-fn verify_stats(dir: &PathBuf, baseline: &str) {
+fn verify_stats(dir: &Path, baseline: &str) {
     verify_json(dir, &format!("{}/estimates.json", baseline));
     verify_json(dir, &format!("{}/sample.json", baseline));
     verify_json(dir, &format!("{}/tukey.json", baseline));
@@ -89,7 +89,7 @@ fn verify_stats(dir: &PathBuf, baseline: &str) {
     verify_file(dir, &format!("{}/raw.csv", baseline));
 }
 
-fn verify_not_exists(dir: &PathBuf, path: &str) {
+fn verify_not_exists(dir: &Path, path: &str) {
     assert!(!dir.join(path).exists());
 }
 


### PR DESCRIPTION
- `clippy::needless_borrowed_reference`
- `clippy::unnecessary_cast`
- `clippy::iter_kv_map`
- `clippy::box_default`
- `clippy::single_component_path_imports`
- `clippy::needless_borrow`
- `clippy::ptr_arg`
