### PR TITLE
Remove futures from async feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ default = ["rayon", "plotters", "cargo_bench_support"]
 real_blackbox = []
 
 # Enable async/await support
-async = ["futures"]
+async = []
 
 # These features enable built-in support for running async benchmarks on each different async
 # runtime.


### PR DESCRIPTION
We don't need to depend on futures with async feature.