### PR TITLE
fix >5s quick mode crash, resolve #658

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+ - Quick mode (--quick) no longer crashes with measured times over 5 seconds when --noplot is not active
+
 ## [0.5.0] - 2023-05-23
 
 ### Changed

--- a/src/routine.rs
+++ b/src/routine.rs
@@ -103,7 +103,8 @@ pub(crate) trait Routine<M: Measurement, T: ?Sized> {
             // Early exit for extremely long running benchmarks:
             if time_start.elapsed() > maximum_bench_duration {
                 let iters = vec![n as f64, n as f64].into_boxed_slice();
-                let elapsed = vec![t_prev, t_prev].into_boxed_slice();
+                // prevent gnuplot bug when all values are equal
+                let elapsed = vec![t_prev, t_prev + 0.000001].into_boxed_slice();
                 return (ActualSamplingMode::Flat, iters, elapsed);
             }
 


### PR DESCRIPTION
When using quick mode without "--noplot", any benchmark running over 5 seconds will lead to a crash. This commit fixes this problem by adding a very small amount (currently 0.000001) to the second of the two elapsed times (that will not be reported due to rounding) in order to work around the gnuplot crash. See <https://github.com/bheisler/criterion.rs/issues/658>.
The issue occurred because of the original workaround which passes a single measurement twice to get a valid vector with two elements as an early exit for long running benchmarks.