### PR TITLE
deps: Allow `tempfile` to update past 3.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ default-features = false
 features         = ["svg_backend", "area_series", "line_series"]
 
 [dev-dependencies]
-tempfile   = "~3.5.0"
+tempfile   = "3.5.0"
 approx     = "0.5.0"
 quickcheck = { version = "1.0", default-features = false }
 rand       = "0.8"


### PR DESCRIPTION
When doing this and running `cargo update`, we see this lets us stop having some extra dependencies:

```
    Updating crates.io index
      Adding fastrand v2.0.0
    Updating tempfile v3.5.0 -> v3.7.1
    Removing windows-sys v0.45.0
    Removing windows-targets v0.42.2
    Removing windows_aarch64_gnullvm v0.42.2
    Removing windows_aarch64_msvc v0.42.2
    Removing windows_i686_gnu v0.42.2
    Removing windows_i686_msvc v0.42.2
    Removing windows_x86_64_gnu v0.42.2
    Removing windows_x86_64_gnullvm v0.42.2
    Removing windows_x86_64_msvc v0.42.2
```