### PR TITLE
Fix Label::is_outlier()

### DIFF
--- a/src/stats/univariate/outliers/tukey.rs
+++ b/src/stats/univariate/outliers/tukey.rs
@@ -239,7 +239,7 @@ impl Label {
 
     /// Checks if the data point is labeled as an outlier
     pub fn is_outlier(&self) -> bool {
-        matches!(*self, NotAnOutlier)
+        !matches!(*self, NotAnOutlier)
     }
 
     /// Checks if the data point is labeled as a "severe" outlier


### PR DESCRIPTION
This fixes an enum's predicate method that was incorrectly rewritten when adopting the `matches!` macro. Fixing this makes the "clean sample" blue dots show up on PDF charts again.