### PR TITLE
docs: Fix comments to say clone not to_vec (#715)

### DIFF
--- a/src/bencher.rs
+++ b/src/bencher.rs
@@ -223,7 +223,7 @@ impl<'a, M: Measurement> Bencher<'a, M> {
     ///     let data = create_scrambled_data();
     ///
     ///     c.bench_function("with_setup", move |b| {
-    ///         // This will avoid timing the to_vec call.
+    ///         // This will avoid timing the clone call.
     ///         b.iter_batched(|| data.clone(), |mut data| sort(&mut data), BatchSize::SmallInput)
     ///     });
     /// }
@@ -313,7 +313,7 @@ impl<'a, M: Measurement> Bencher<'a, M> {
     ///     let data = create_scrambled_data();
     ///
     ///     c.bench_function("with_setup", move |b| {
-    ///         // This will avoid timing the to_vec call.
+    ///         // This will avoid timing the clone call.
     ///         b.iter_batched(|| data.clone(), |mut data| sort(&mut data), BatchSize::SmallInput)
     ///     });
     /// }
@@ -602,7 +602,7 @@ impl<'a, 'b, A: AsyncExecutor, M: Measurement> AsyncBencher<'a, 'b, A, M> {
     ///     let data = create_scrambled_data();
     ///
     ///     c.bench_function("with_setup", move |b| {
-    ///         // This will avoid timing the to_vec call.
+    ///         // This will avoid timing the clone call.
     ///         b.iter_batched(|| data.clone(), |mut data| async move { sort(&mut data).await }, BatchSize::SmallInput)
     ///     });
     /// }
@@ -700,7 +700,7 @@ impl<'a, 'b, A: AsyncExecutor, M: Measurement> AsyncBencher<'a, 'b, A, M> {
     ///     let data = create_scrambled_data();
     ///
     ///     c.bench_function("with_setup", move |b| {
-    ///         // This will avoid timing the to_vec call.
+    ///         // This will avoid timing the clone call.
     ///         b.iter_batched(|| data.clone(), |mut data| async move { sort(&mut data).await }, BatchSize::SmallInput)
     ///     });
     /// }


### PR DESCRIPTION
In `bencher.rs` there are four doc comments like this:

```rust
/// c.bench_function("with_setup", move |b| {
///     // This will avoid timing the to_vec call.
///     b.iter_batched(|| data.clone(), /* ... */)
/// });
```

They should say `clone` not `to_vec` because the setup code is `|| data.clone()`.