### PR TITLE
Increase criterion version in quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To start with Criterion.<span></span>rs, add the following to your `Cargo.toml` 
 
 ```toml
 [dev-dependencies]
-criterion = { version = "0.4", features = ["html_reports"] }
+criterion = { version = "0.5", features = ["html_reports"] }
 
 [[bench]]
 name = "my_benchmark"


### PR DESCRIPTION
The version is currently set as `0.4` even though `0.5` has been available since May.