### PR TITLE
Use unicode minus signs in HTML output

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -37,16 +37,17 @@ pub fn short(n: f64) -> String {
 fn signed_short(n: f64) -> String {
     let n_abs = n.abs();
 
+    let sign = if n >= 0.0 {'+'} else {'\u{2212}'};
     if n_abs < 10.0 {
-        format!("{:+.4}", n)
+        format!("{}{:.4}", sign, n_abs)
     } else if n_abs < 100.0 {
-        format!("{:+.3}", n)
+        format!("{}{:.3}", sign, n_abs)
     } else if n_abs < 1000.0 {
-        format!("{:+.2}", n)
+        format!("{}{:.2}", sign, n_abs)
     } else if n_abs < 10000.0 {
-        format!("{:+.1}", n)
+        format!("{}{:.1}", sign, n_abs)
     } else {
-        format!("{:+.0}", n)
+        format!("{}{:.0}", sign, n_abs)
     }
 }
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -125,7 +125,7 @@ mod test {
         while float > -999_999.9 {
             let string = signed_short(float);
             println!("{}", string);
-            assert!(string.len() <= 7);
+            assert!(string.chars().count() <= 7);
             float *= 2.0;
         }
     }

--- a/src/format.rs
+++ b/src/format.rs
@@ -37,7 +37,7 @@ pub fn short(n: f64) -> String {
 fn signed_short(n: f64) -> String {
     let n_abs = n.abs();
 
-    let sign = if n >= 0.0 {'+'} else {'\u{2212}'};
+    let sign = if n >= 0.0 { '+' } else { '\u{2212}' };
     if n_abs < 10.0 {
         format!("{}{:.4}", sign, n_abs)
     } else if n_abs < 100.0 {


### PR DESCRIPTION
Currently, it just produces hyphen-minuses (-), but these match up poorly with the plus signs. Compare, although this may be typeface-dependant: -2%, +2%, −2%. There's more on this [here, among other places](https://graphicdesign.stackexchange.com/questions/68674/what-s-the-right-character-for-a-minus-sign).