### PR TITLE
Book: CD to Github page

### DIFF
--- a/.github/workflows/book.yaml
+++ b/.github/workflows/book.yaml
@@ -1,0 +1,62 @@
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'book/**'
+      - ".github/workflows/book.yaml"
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets the GITHUB_TOKEN permissions to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+name: book
+env:
+  CARGO_TERM_COLOR: always
+
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install latest mdbook
+        run: |
+          tag=$(curl 'https://api.github.com/repos/rust-lang/mdbook/releases/latest' | jq -r '.tag_name')
+          url="https://github.com/rust-lang/mdbook/releases/download/${tag}/mdbook-${tag}-x86_64-unknown-linux-gnu.tar.gz"
+          mkdir mdbook
+          curl -sSL $url | tar -xz --directory=./mdbook
+          echo `pwd`/mdbook >> $GITHUB_PATH
+      - name: Install latest linkcheck
+        # Adapted from https://github.com/Michael-F-Bryan/mdbook-linkcheck README
+        run: |
+          mkdir -p mdbook-linkcheck && \
+          curl -L https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/latest/download/mdbook-linkcheck.x86_64-unknown-linux-gnu.zip -o mdbook-linkcheck/mdbook-linkcheck.zip && \
+          unzip -d ./mdbook-linkcheck mdbook-linkcheck/mdbook-linkcheck.zip && \
+          chmod +x mdbook-linkcheck/mdbook-linkcheck && \
+          echo `pwd`/mdbook-linkcheck >> $GITHUB_PATH
+      - name: Build Book
+        run: |
+          cd book && mdbook build
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          # Upload entire repository
+          path: 'book/book/html'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/book/book.toml
+++ b/book/book.toml
@@ -4,6 +4,7 @@ description = "User Guide and Other Prose Documentation For Criterion.rs"
 author = "Brook Heisler"
 
 [output.html]
+git-repository-url = "https://github.com/bheisler/criterion.rs"
 
 [output.linkcheck]
 #follow-web-links = true


### PR DESCRIPTION
close https://github.com/bheisler/criterion.rs/issues/677

see https://github.com/bheisler/criterion.rs/commit/d71f0908c82f44292d6c5a3a2f49b2ce378fa572 for technical details.

The current issue is that its posting the book at `https://bheisler.github.io/criterion.rs/` instead of `https://bheisler.github.io/criterion.rs/book/index.html` and I'm not sure how it'd plays with the master doc. before trying to fix this, I want to be sure the idea of CD for the book is validated.

In fact considering the "master" documentation still displays 0.3.4  and has not been updated for 2 years I think it'd be safe to scrape it and only serve the book: https://bheisler.github.io/criterion.rs/criterion/