### PR TITLE
Fix itertools dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ exclude     = ["book/*"]
 anes           = "0.1.4"
 once_cell      = "1.14"
 criterion-plot = { path = "plot", version = "0.5.0" }
-itertools      = ">=0.10, <12"
+itertools      = ">=0.10, <=0.12"
 serde          = "1.0"
 serde_json     = "1.0"
 serde_derive   = "1.0"

--- a/plot/Cargo.toml
+++ b/plot/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 cast = "0.3"
-itertools = ">=0.10, <12"
+itertools = ">=0.10, <=0.12"
 
 [dev-dependencies]
 itertools-num = "0.1"


### PR DESCRIPTION
Fixes itertools dependency (`0.12` instead of `12`). 
Include version 0.12,  to deduplicate dependencies
