### PR TITLE
Use alloca to address memory layout effects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ tokio = { version = "1.0", default-features = false, features = [
   "rt",
 ], optional = true }
 async-std = { version = "1.9", optional = true }
+alloca = "0.3.3"
 
 [dependencies.plotters]
 version          = "^0.3.1"
@@ -61,14 +62,7 @@ futures    = { version = "0.3", default_features = false, features = ["executor"
 maintenance = { status = "passively-maintained" }
 
 [features]
-stable = [
-  "csv_output",
-  "html_reports",
-  "async_futures",
-  "async_smol",
-  "async_tokio",
-  "async_std",
-]
+stable = ["csv_output", "html_reports", "async_futures", "async_smol", "async_tokio", "async_std"]
 default = ["rayon", "plotters", "cargo_bench_support"]
 
 # Enable use of the nightly-only test::black_box function to discourage compiler optimizations.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ tokio = { version = "1.0", default-features = false, features = [
   "rt",
 ], optional = true }
 async-std = { version = "1.9", optional = true }
-alloca = "0.3.3"
+alloca = "0.3.4"
 
 [dependencies.plotters]
 version          = "^0.3.1"

--- a/src/routine.rs
+++ b/src/routine.rs
@@ -245,7 +245,7 @@ where
         let mut results = Vec::with_capacity(iters.len());
         results.resize(iters.len(), 0.0);
         for (i, iters) in iters.iter().enumerate() {
-            let stack_alloc = i % 2048;
+            let stack_alloc = i % 4096; // default page size
             #[cfg(any(target_family = "unix", target_family = "windows"))]
             {
                 alloca::with_alloca(

--- a/src/routine.rs
+++ b/src/routine.rs
@@ -242,15 +242,15 @@ where
             elapsed_time: Duration::from_millis(0),
         };
 
-        iters
-            .iter()
-            .map(|iters| {
-                b.iters = *iters;
-                (*f)(&mut b, black_box(parameter));
-                b.assert_iterated();
-                m.to_f64(&b.value)
-            })
-            .collect()
+        let mut results = Vec::with_capacity(iters.len());
+        results.resize(iters.len(), 0.0);
+        for (i, iters) in iters.iter().enumerate() {
+            b.iters = *iters;
+            (*f)(&mut b, black_box(parameter));
+            b.assert_iterated();
+            results[i] = m.to_f64(&b.value);
+        }
+        results
     }
 
     fn warm_up(&mut self, m: &M, how_long: Duration, parameter: &T) -> (u64, u64) {

--- a/src/routine.rs
+++ b/src/routine.rs
@@ -246,15 +246,25 @@ where
         results.resize(iters.len(), 0.0);
         for (i, iters) in iters.iter().enumerate() {
             let stack_alloc = i % 2048;
-            alloca::with_alloca(
-                stack_alloc, /* how much bytes we want to allocate */
-                |_memory: &mut [core::mem::MaybeUninit<u8>] /* dynamically stack allocated slice itself */| {
-                    b.iters = *iters;
-                    (*f)(&mut b, black_box(parameter));
-                    b.assert_iterated();
-                    results[i] = m.to_f64(&b.value);
-                },
-            );
+            #[cfg(any(target_family = "unix", target_family = "windows"))]
+            {
+                alloca::with_alloca(
+                    stack_alloc, /* how much bytes we want to allocate */
+                    |_memory: &mut [core::mem::MaybeUninit<u8>] /* dynamically stack allocated slice itself */| {
+                        b.iters = *iters;
+                        (*f)(&mut b, black_box(parameter));
+                        b.assert_iterated();
+                        results[i] = m.to_f64(&b.value);
+                    },
+                );
+            }
+            #[cfg(not(any(target_family = "unix", target_family = "windows")))]
+            {
+                b.iters = *iters;
+                (*f)(&mut b, black_box(parameter));
+                b.assert_iterated();
+                results[i] = m.to_f64(&b.value);
+            }
         }
         results
     }


### PR DESCRIPTION
- replace collect with Vec::reserve
the iter collect pollutes the call stack (10 levels of calls)
- offset tests with alloca
As mentioned in #334, randomness in memory layout has a huge impact on the bench results. When I benchmark with criterion it's not uncommon to see effects of +-30%. Tests seem much more stable with alloca, there's still random 6% jumps in one test I've been running.


Adresses #334