### PR TITLE
Remove is terminal dependency

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.64.0 # MSRV
+          - 1.70.0 # MSRV
           - nightly
 
     steps:
@@ -33,14 +33,6 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         name: Load dependencies from cache
-
-      - name: Fix dep versions for MSRV
-        if: ${{ matrix.rust == '1.64.0' }}
-        run: |
-          cargo update -p clap --precise 4.3.24 # 4.4 moves to msrv 1.70
-          cargo update -p clap_lex --precise 0.5.0 # 0.5.1 moves to msrv 1.70 in a patch release
-          cargo update -p anstyle --precise 1.0.2 # 1.0.3 moves to msrv 1.70 in a patch release
-          cargo update -p regex --precise 1.9.6 # 1.10 moves to msrv 1.65
 
       - name: Build with stable features
         run: cargo build --features stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- MSRV bumped to 1.70
 
 ## [0.5.1] - 2023-05-26
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ serde          = "1.0"
 serde_json     = "1.0"
 serde_derive   = "1.0"
 ciborium       = "0.2.0"
-is-terminal    = "0.4.6"
 clap           = { version = "4", default-features = false, features = ["std", "help"] }
 walkdir        = "2.3"
 tinytemplate   = "1.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,6 @@ extern crate approx;
 #[cfg(test)]
 extern crate quickcheck;
 
-use is_terminal::IsTerminal;
 use regex::Regex;
 
 #[cfg(feature = "real_blackbox")]
@@ -77,7 +76,7 @@ use std::cell::RefCell;
 use std::collections::HashSet;
 use std::default::Default;
 use std::env;
-use std::io::stdout;
+use std::io::{stdout, IsTerminal};
 use std::net::TcpStream;
 use std::path::{Path, PathBuf};
 use std::process::Command;


### PR DESCRIPTION
Hello,

In rust 1.70 [IsTerminal](https://doc.rust-lang.org/stable/std/io/trait.IsTerminal.html) is stabilized. This PR removes the is-terminal dependency which removes some large dependencies.

This PR does bump up the MSRV, but given that we are removing a large dependency I feel its a worthy looking into.