### PR TITLE
Fix documents and `bencher_compat` dep refer outdated criterion v0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To start with Criterion.<span></span>rs, add the following to your `Cargo.toml` 
 
 ```toml
 [dev-dependencies]
-criterion = { version = "0.4", features = ["html_reports"] }
+criterion = { version = "0.5", features = ["html_reports"] }
 
 [[bench]]
 name = "my_benchmark"

--- a/bencher_compat/Cargo.toml
+++ b/bencher_compat/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["development-tools::profiling"]
 license = "Apache-2.0/MIT"
 
 [dependencies]
-criterion = { version = "0.4.0", path = "..", default-features = false }
+criterion = { version = "0.5.1", path = "..", default-features = false }
 
 [features]
 real_blackbox = ["criterion/real_blackbox"]

--- a/book/src/user_guide/custom_test_framework.md
+++ b/book/src/user_guide/custom_test_framework.md
@@ -15,7 +15,7 @@ Once that's installed, add the dependencies to your Cargo.toml:
 
 ```toml
 [dev-dependencies]
-criterion = "0.4"
+criterion = "0.5"
 criterion-macro = "0.4"
 ```
 


### PR DESCRIPTION
This PR fixes the following two issues:

- Documents including the quick start guide still use old criterion v0.4. When users refer them, they would accidentally use the old version instead of the latest v0.5.1
- `criterion_bencher_compat` depends on `criterion` crate v0.4. But the current version in the workspace is v0.5.1. So `cargo check` reports the following error
  ```
  error: failed to select a version for the requirement `criterion = "^0.4.0"`
  candidate versions found which didn't match: 0.5.1
  location searched: /path/to/criterion.rs
  required by package `criterion_bencher_compat v0.4.0 (/path/to/criterion.rs/bencher_compat)`
  ```