### PR TITLE
Fix gnuplot --version encoding handling on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 - MSRV bumped to 1.70
 
+### Fixed
+
+- gnuplot version is now correctly detected when using certain Windows binaries/configurations that used to fail
+
 ## [0.5.1] - 2023-05-26
 
 ### Fixed


### PR DESCRIPTION
In some configurations, `gnuplot --version` will emit output as UTF-16 bytes instead of UTF-8. This is not expected by `parse_version()` which always expects UTF-8.

This change enhances `parse_version()` with a simple fallback - if UTF-8 parsing fails, it will try again with UTF-16.

Fixes #570.