### PR TITLE
Update criterion version in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To start with Criterion.<span></span>rs, add the following to your `Cargo.toml` 
 
 ```toml
 [dev-dependencies]
-criterion = { version = "0.4", features = ["html_reports"] }
+criterion = { version = "0.5", features = ["html_reports"] }
 
 [[bench]]
 name = "my_benchmark"

--- a/book/src/user_guide/custom_test_framework.md
+++ b/book/src/user_guide/custom_test_framework.md
@@ -15,7 +15,7 @@ Once that's installed, add the dependencies to your Cargo.toml:
 
 ```toml
 [dev-dependencies]
-criterion = "0.4"
+criterion = "0.5"
 criterion-macro = "0.4"
 ```
 

--- a/book/src/user_guide/html_report.md
+++ b/book/src/user_guide/html_report.md
@@ -3,7 +3,7 @@
 Starting with Criterion.rs 0.4.0 HTML reports must be explicitly enabled via the `html_reports` [feature](https://doc.rust-lang.org/cargo/reference/features.html#dependency-features):
 ```toml
 [dev-dependencies]
-criterion = {version = "0.4.0", features = ["html_reports"] }
+criterion = { version = "0.5", features = ["html_reports"] }
 ```
 Criterion.rs can generate an HTML report displaying the results of the benchmark under
 `target/criterion/reports/index.html`. By default, the plots are generated using

--- a/book/src/user_guide/plots_and_graphs.md
+++ b/book/src/user_guide/plots_and_graphs.md
@@ -11,7 +11,7 @@ have introduced a cargo feature for plot and html generation. In order to activa
 generation make sure that your `Cargo.toml` activates the feature:
 
 ```toml
-criterion = { version = "0.4", features = ["html_reports"] }
+criterion = { version = "0.5", features = ["html_reports"] }
 ```
 
 ## File Structure


### PR DESCRIPTION
Noticed that the README still uses `0.4` in the Quickstart section. I updated all the examples that were using 0.4 in the docs. Not 100% sure about `html_report.md` because it explicitly mentions 0.4.0, but it's probably fine? Let me know