### PR TITLE
Do not redundantly import `std::iter::IntoIterator`

### DIFF
--- a/plot/src/axis.rs
+++ b/plot/src/axis.rs
@@ -1,7 +1,6 @@
 //! Coordinate axis
 
 use std::borrow::Cow;
-use std::iter::IntoIterator;
 
 use crate::map;
 use crate::traits::{Configure, Data, Set};

--- a/plot/src/candlestick.rs
+++ b/plot/src/candlestick.rs
@@ -1,7 +1,6 @@
 //! "Candlestick" plots
 
 use std::borrow::Cow;
-use std::iter::IntoIterator;
 
 use crate::data::Matrix;
 use crate::traits::{self, Data, Set};

--- a/plot/src/curve.rs
+++ b/plot/src/curve.rs
@@ -1,7 +1,6 @@
 //! Simple "curve" like plots
 
 use std::borrow::Cow;
-use std::iter::IntoIterator;
 
 use crate::data::Matrix;
 use crate::traits::{self, Data, Set};

--- a/plot/src/errorbar.rs
+++ b/plot/src/errorbar.rs
@@ -1,7 +1,6 @@
 //! Error bar plots
 
 use std::borrow::Cow;
-use std::iter::IntoIterator;
 
 use crate::data::Matrix;
 use crate::traits::{self, Data, Set};

--- a/plot/src/filledcurve.rs
+++ b/plot/src/filledcurve.rs
@@ -1,7 +1,6 @@
 //! Filled curve plots
 
 use std::borrow::Cow;
-use std::iter::IntoIterator;
 
 use crate::data::Matrix;
 use crate::traits::{self, Data, Set};


### PR DESCRIPTION
Rust now warns about duplicate imports. `std::iter::IntoIterator` is part of the Rust prelude since Rust 2015. This prevents `criterion-plot` from compiling with recent Rust versions because of `#![deny(warnings)]`.