### PR TITLE
Make CI green again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ serde          = "1.0"
 serde_json     = "1.0"
 serde_derive   = "1.0"
 ciborium       = "0.2.0"
-clap           = { version = "4", default-features = false, features = ["std", "help"] }
+clap           = { version = "=4.4.9", default-features = false, features = ["std", "help"] }
 walkdir        = "2.3"
 tinytemplate   = "1.1"
 cast           = "0.3"

--- a/plot/src/axis.rs
+++ b/plot/src/axis.rs
@@ -1,7 +1,6 @@
 //! Coordinate axis
 
 use std::borrow::Cow;
-use std::iter::IntoIterator;
 
 use crate::map;
 use crate::traits::{Configure, Data, Set};

--- a/plot/src/candlestick.rs
+++ b/plot/src/candlestick.rs
@@ -1,7 +1,6 @@
 //! "Candlestick" plots
 
 use std::borrow::Cow;
-use std::iter::IntoIterator;
 
 use crate::data::Matrix;
 use crate::traits::{self, Data, Set};

--- a/plot/src/curve.rs
+++ b/plot/src/curve.rs
@@ -1,7 +1,6 @@
 //! Simple "curve" like plots
 
 use std::borrow::Cow;
-use std::iter::IntoIterator;
 
 use crate::data::Matrix;
 use crate::traits::{self, Data, Set};

--- a/plot/src/errorbar.rs
+++ b/plot/src/errorbar.rs
@@ -1,7 +1,6 @@
 //! Error bar plots
 
 use std::borrow::Cow;
-use std::iter::IntoIterator;
 
 use crate::data::Matrix;
 use crate::traits::{self, Data, Set};

--- a/plot/src/filledcurve.rs
+++ b/plot/src/filledcurve.rs
@@ -1,7 +1,6 @@
 //! Filled curve plots
 
 use std::borrow::Cow;
-use std::iter::IntoIterator;
 
 use crate::data::Matrix;
 use crate::traits::{self, Data, Set};


### PR DESCRIPTION
Version of clap above 4.4.9 require Rust 1.74, which exceeds criterion's MSRV of 1.70, and some entities belong to the Rust profile.