### PR TITLE
book: fix an example of throughput measurements

### DIFF
--- a/book/src/user_guide/advanced_configuration.md
+++ b/book/src/user_guide/advanced_configuration.md
@@ -101,7 +101,7 @@ fn bench(c: &mut Criterion) {
     let mut group = c.benchmark_group("throughput-example");
     for (i, elements) in [elements_1, elements_2].iter().enumerate() {
         group.throughput(Throughput::Elements(elements.len() as u64));
-        group.bench_with_input(format!("Encode {}", i), elements, |elems, b| {
+        group.bench_with_input(format!("Encode {}", i), elements, |b, elems| {
             b.iter(||encode(elems))
         });
     }

--- a/book/src/user_guide/advanced_configuration.md
+++ b/book/src/user_guide/advanced_configuration.md
@@ -100,7 +100,7 @@ fn bench(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("throughput-example");
     for (i, elements) in [elements_1, elements_2].iter().enumerate() {
-        group.throughput(Throughput::Elements(elems.len() as u64));
+        group.throughput(Throughput::Elements(elements.len() as u64));
         group.bench_with_input(format!("Encode {}", i), elements, |elems, b| {
             b.iter(||encode(elems))
         });


### PR DESCRIPTION
This PR fixes a mistake in an example of throughput measurements in the book.

In an example code of throughput measurements, 

1. `elems` is used before it is defined. This seems to be a mistake for `elements`.
2. the arguments of the third parameter `bench_with_input` is `elem, b`. It seems to be a mistake for `b, elem`