### PR TITLE
Generate doc comment on benchmark runner in criterion_group macro

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -64,6 +64,7 @@
 #[macro_export]
 macro_rules! criterion_group {
     (name = $name:ident; config = $config:expr; targets = $( $target:path ),+ $(,)*) => {
+        #[doc="The function which runs the benchmarks."]
         pub fn $name() {
             let mut criterion: $crate::Criterion<_> = $config
                 .configure_from_args();


### PR DESCRIPTION
tl;dr: One-liner to add a doc comment to the generated benchmark runner fn from the `criterion_group!` macro.

The `rustc` lint [`missing-docs`](https://doc.rust-lang.org/rustdoc/lints.html#missing_docs) is triggered when using the `criterion_group!` macro. For users who specify the lint on their `rustc` command line, this can generate a warning that they are unable to quiet without an inner allow attribute (e.g. using `#![allow(missing-docs)]` at the head of their source file). This will surpress any other missing docs in their own code, which may be unexpected behavior.

I don't see any real downsides to this change, but I'm brand new to the criterion.rs codebase. Comments, discussion, and suggestions very welcome on this proposed change. For instance, I have no idea if this change warrants an entry in the changelog. Cheers!