### PR TITLE
Allow missing_docs in criterion_group

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -64,6 +64,7 @@
 #[macro_export]
 macro_rules! criterion_group {
     (name = $name:ident; config = $config:expr; targets = $( $target:path ),+ $(,)*) => {
+        #[allow(missing_docs)]
         pub fn $name() {
             let mut criterion: $crate::Criterion<_> = $config
                 .configure_from_args();


### PR DESCRIPTION
This lint gets flagged in user code if the missing_docs warning is enabled. Adding a doc comment to the function would also fix this.