### PR TITLE
serde: Use derives via feature, no more macro_use.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,8 @@ anes           = "0.1.4"
 once_cell      = "1.14"
 criterion-plot = { path = "plot", version = "0.5.0" }
 itertools      = ">=0.10, <=0.12"
-serde          = "1.0"
+serde          = { version = "1.0", features = ["derive"] }
 serde_json     = "1.0"
-serde_derive   = "1.0"
 ciborium       = "0.2.0"
 clap           = { version = "=4.4.9", default-features = false, features = ["std", "help"] }
 walkdir        = "2.3"

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,5 +1,6 @@
 use crate::report::BenchmarkId as InternalBenchmarkId;
 use crate::Throughput;
+use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 use std::convert::TryFrom;
 use std::io::{Read, Write};

--- a/src/csv_report.rs
+++ b/src/csv_report.rs
@@ -3,6 +3,7 @@ use crate::measurement::ValueFormatter;
 use crate::report::{BenchmarkId, MeasurementData, Report, ReportContext};
 use crate::Throughput;
 use csv::Writer;
+use serde::Serialize;
 use std::io::Write;
 use std::path::Path;
 

--- a/src/estimate.rs
+++ b/src/estimate.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 use std::fmt;
 
 use crate::stats::Distribution;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,12 +34,10 @@ extern crate approx;
 extern crate quickcheck;
 
 use regex::Regex;
+use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "real_blackbox")]
 extern crate test;
-
-#[macro_use]
-extern crate serde_derive;
 
 // Needs to be declared before other modules
 // in order to be usable there.

--- a/src/report.rs
+++ b/src/report.rs
@@ -11,6 +11,7 @@ use crate::stats::univariate::Sample;
 use crate::stats::Distribution;
 use crate::{PlotConfiguration, Throughput};
 use anes::{Attribute, ClearLine, Color, ResetAttributes, SetAttribute, SetForegroundColor};
+use serde::{Deserialize, Serialize};
 use std::cmp;
 use std::collections::HashSet;
 use std::fmt;


### PR DESCRIPTION
We no longer need `#[macro_use] extern crate serde_derive;` as we can just use the macros like normal in Rust 2018 and later.