### PR TITLE
deps: Require itertools 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ exclude     = ["book/*"]
 anes           = "0.1.4"
 once_cell      = "1.14"
 criterion-plot = { path = "plot", version = "0.5.0" }
-itertools      = ">=0.10, <=0.12"
+itertools      = "0.13"
 serde          = { version = "1.0", features = ["derive"] }
 serde_json     = "1.0"
 ciborium       = "0.2.0"

--- a/plot/Cargo.toml
+++ b/plot/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 cast = "0.3"
-itertools = ">=0.10, <=0.12"
+itertools = "0.13"
 
 [dev-dependencies]
 itertools-num = "0.1"

--- a/plot/src/candlestick.rs
+++ b/plot/src/candlestick.rs
@@ -140,7 +140,7 @@ where
         } = candlesticks;
 
         let data = Matrix::new(
-            izip!(x, box_min, whisker_min, whisker_high, box_high),
+            itertools::izip!(x, box_min, whisker_min, whisker_high, box_high),
             (x_factor, y_factor, y_factor, y_factor, y_factor),
         );
         self.plots

--- a/plot/src/curve.rs
+++ b/plot/src/curve.rs
@@ -262,7 +262,7 @@ where
         let (x_factor, y_factor) =
             crate::scale_factor(&self.axes, props.axes.unwrap_or(crate::Axes::BottomXLeftY));
 
-        let data = Matrix::new(izip!(x, y), (x_factor, y_factor));
+        let data = Matrix::new(itertools::izip!(x, y), (x_factor, y_factor));
         self.plots.push(Plot::new(data, &props));
         self
     }

--- a/plot/src/errorbar.rs
+++ b/plot/src/errorbar.rs
@@ -259,7 +259,7 @@ where
             } => (x, y, y_low, y_high, y_factor),
         };
         let data = Matrix::new(
-            izip!(x, y, length, height),
+            itertools::izip!(x, y, length, height),
             (x_factor, y_factor, e_factor, e_factor),
         );
         self.plots.push(Plot::new(

--- a/plot/src/filledcurve.rs
+++ b/plot/src/filledcurve.rs
@@ -132,7 +132,7 @@ where
         let (x_factor, y_factor) =
             crate::scale_factor(&self.axes, props.axes.unwrap_or(crate::Axes::BottomXLeftY));
 
-        let data = Matrix::new(izip!(x, y1, y2), (x_factor, y_factor, y_factor));
+        let data = Matrix::new(itertools::izip!(x, y1, y2), (x_factor, y_factor, y_factor));
         self.plots.push(Plot::new(data, &props));
         self
     }

--- a/plot/src/lib.rs
+++ b/plot/src/lib.rs
@@ -372,8 +372,6 @@
 #![allow(clippy::many_single_char_names)]
 
 extern crate cast;
-#[macro_use]
-extern crate itertools;
 
 use std::borrow::Cow;
 use std::fmt;

--- a/src/plot/gnuplot_backend/summary.rs
+++ b/src/plot/gnuplot_backend/summary.rs
@@ -83,7 +83,7 @@ pub fn line_comparison(
     // This assumes the curves are sorted. It also assumes that the benchmark IDs all have numeric
     // values or throughputs and that value is sensible (ie. not a mix of bytes and elements
     // or whatnot)
-    for (key, group) in &all_curves.iter().group_by(|&&&(id, _)| &id.function_id) {
+    for (key, group) in &all_curves.iter().chunk_by(|&&&(id, _)| &id.function_id) {
         let mut tuples: Vec<_> = group
             .map(|&&(id, ref sample)| {
                 // Unwrap is fine here because it will only fail if the assumptions above are not true

--- a/src/plot/plotters_backend/summary.rs
+++ b/src/plot/plotters_backend/summary.rs
@@ -131,7 +131,7 @@ fn line_comparison_series_data<'a>(
     // This assumes the curves are sorted. It also assumes that the benchmark IDs all have numeric
     // values or throughputs and that value is sensible (ie. not a mix of bytes and elements
     // or whatnot)
-    for (key, group) in &all_curves.iter().group_by(|&&&(id, _)| &id.function_id) {
+    for (key, group) in &all_curves.iter().chunk_by(|&&&(id, _)| &id.function_id) {
         let mut tuples: Vec<_> = group
             .map(|&&(id, ref sample)| {
                 // Unwrap is fine here because it will only fail if the assumptions above are not true


### PR DESCRIPTION
Itertools API changed slightly and they deprecated `group_by`,so just require latest for now.

Also, remove uses of `#[macro_use]` and `extern crate` with `itertools`.