### PR TITLE
Remove remaining uses of `extern crate`.

### DIFF
--- a/bencher_compat/benches/bencher_example.rs
+++ b/bencher_compat/benches/bencher_example.rs
@@ -1,7 +1,4 @@
-#[macro_use]
-extern crate criterion_bencher_compat;
-
-use criterion_bencher_compat::Bencher;
+use criterion_bencher_compat::{benchmark_group, benchmark_main, Bencher};
 
 fn a(bench: &mut Bencher) {
     bench.iter(|| {

--- a/bencher_compat/src/lib.rs
+++ b/bencher_compat/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate criterion;
-
 pub use std::hint::black_box;
 pub use criterion::Criterion;
 use criterion::measurement::WallTime;

--- a/plot/src/lib.rs
+++ b/plot/src/lib.rs
@@ -371,8 +371,6 @@
 #![allow(clippy::doc_markdown)]
 #![allow(clippy::many_single_char_names)]
 
-extern crate cast;
-
 use std::borrow::Cow;
 use std::fmt;
 use std::fs::File;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,12 +26,6 @@
 #[cfg(all(feature = "rayon", target_arch = "wasm32"))]
 compile_error!("Rayon cannot be used when targeting wasi32. Try disabling default features.");
 
-#[cfg(test)]
-extern crate approx;
-
-#[cfg(test)]
-extern crate quickcheck;
-
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
These are not required in Rust edition 2018 and later.