### PR TITLE
use meaurement_time instead of target_time in the warning message

### DIFF
--- a/book/src/user_guide/advanced_configuration.md
+++ b/book/src/user_guide/advanced_configuration.md
@@ -53,6 +53,18 @@ criterion_group!{
 criterion_main!(benches);
 ```
 
+It is also possible to change the Criterion.rs' default measurement time for benchmarks (defaults to 5.0s).
+
+```rust
+fn bench(c: &mut Criterion) {
+    let mut group = c.benchmark_group("measurement-time-example");
+    group.measurement_time(Duration::from_secs(30));
+    group.bench_function("my-function", |b| b.iter(|| my_function()));
+    group.finish();
+}
+
+```
+
 ## Throughput Measurements
 
 When benchmarking some types of code it is useful to measure the throughput as well as the iteration time, either in bytes per second or elements per second. Criterion.rs can estimate the throughput of a benchmark, but it needs to know how many bytes or elements each iteration will process.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1399,7 +1399,7 @@ impl ActualSamplingMode {
                     let recommended_sample_size =
                         ActualSamplingMode::recommend_linear_sample_size(m_ns as f64, met);
                     let actual_time = Duration::from_nanos(expected_ns as u64);
-                    eprint!("\nWarning: Unable to complete {} samples in {:.1?}. You may wish to increase target time to {:.1?}",
+                    eprint!("\nWarning: Unable to complete {} samples in {:.1?}. You may wish to increase measurement time to {:.1?}",
                             n, target_time, actual_time);
 
                     if recommended_sample_size != n {
@@ -1428,7 +1428,7 @@ impl ActualSamplingMode {
                     let recommended_sample_size =
                         ActualSamplingMode::recommend_flat_sample_size(m_ns, met);
                     let actual_time = Duration::from_nanos(expected_ns as u64);
-                    eprint!("\nWarning: Unable to complete {} samples in {:.1?}. You may wish to increase target time to {:.1?}",
+                    eprint!("\nWarning: Unable to complete {} samples in {:.1?}. You may wish to increase measurement time to {:.1?}",
                             n, target_time, actual_time);
 
                     if recommended_sample_size != n {


### PR DESCRIPTION
For a while my benchmarks have been warning me the following:
```
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 82.6s, or reduce sample count to 10.
```

When I finally decided to do something about it, I was surprised to see that there was no `target_time` property in the benchmark group. To no avail, I googled how to change "target time". I found #322 which didn't really fix my issue. It took me a while to figure out that `target time == measurement time`.

This PR changes the warnings from `target` -> `measurement` to better match the name of the actual user facing config name. 

Seems like the warning was written like that because the name of the parameter in mode function (`iteration_counts`) is called `target_time`.

Also threw an optional new snippet in the book which I missed when looking up how to change target time. 