### PR TITLE
fix build on minimal versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ exclude     = ["book/*"]
 anes           = "0.1.4"
 criterion-plot = { path = "plot", version = "0.5.0" }
 itertools      = "0.13"
-serde          = { version = "1.0", features = ["derive"] }
-serde_json     = "1.0"
+serde          = { version = "1.0.100", features = ["derive"] }
+serde_json     = "1.0.100"
 ciborium       = "0.2.0"
 clap           = { version = "=4.4.9", default-features = false, features = ["std", "help"] }
 walkdir        = "2.3"
@@ -32,7 +32,7 @@ tinytemplate   = "1.1"
 cast           = "0.3"
 num-traits     = { version = "0.2", default-features = false, features = ["std"] }
 oorandom       = "11.1"
-regex          = { version = "1.5", default-features = false, features = ["std"] }
+regex          = { version = "1.5.1", default-features = false, features = ["std"] }
 
 # Optional dependencies
 rayon = { version = "1.3", optional = true }
@@ -45,7 +45,7 @@ tokio = { version = "1.0", default-features = false, features = [
 async-std = { version = "1.9", optional = true }
 
 [dependencies.plotters]
-version          = "^0.3.1"
+version          = "^0.3.2"
 optional         = true
 default-features = false
 features         = ["svg_backend", "area_series", "line_series"]


### PR DESCRIPTION
38b6d7fc71a6e9485e6cc8bef4179735ba9f4cf8
```terminal
$ cargo +nightly update -Z minimal-versions && cargo +stable --version && cargo +stable check
    Updating crates.io index
     Locking 0 packages to earliest compatible versions
note: pass `--verbose` to see 161 unchanged dependencies behind latest
cargo 1.82.0 (8f40fc59f 2024-08-21)
    Checking serde v1.0.85
    Checking regex v1.5.0
    Checking criterion-plot v0.5.0 (/home/tfukaya/codes/criterion.rs/plot)
    Checking clap v4.4.9
error[E0433]: failed to resolve: use of undeclared crate or module `syntax`
 --> /home/tfukaya/.cargo/registry/src/index.crates.io-6f17d22bba15001f/regex-1.5.0/src/literal/mod.rs:9:9
  |
9 |     use syntax::hir::literal::Literals;
  |         ^^^^^^ use of undeclared crate or module `syntax`

error[E0554]: `#![feature]` may not be used on the stable release channel
  --> /home/tfukaya/.cargo/registry/src/index.crates.io-6f17d22bba15001f/serde-1.0.85/src/lib.rs:85:35
   |
85 | #![cfg_attr(feature = "unstable", feature(specialization, never_type))]
   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error[E0554]: `#![feature]` may not be used on the stable release channel
  --> /home/tfukaya/.cargo/registry/src/index.crates.io-6f17d22bba15001f/serde-1.0.85/src/lib.rs:86:32
   |
86 | #![cfg_attr(feature = "alloc", feature(alloc))]
   |                                ^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0433`.
error: could not compile `regex` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
For more information about this error, try `rustc --explain E0554`.
error: could not compile `serde` (lib) due to 2 previous errors
```

892790297399fb8a35a34051e6bb14af6c1bedc2
```terminal
$ cargo +nightly update -Z minimal-versions && cargo +stable --version && cargo +stable check
    Updating crates.io index
     Locking 6 packages to earliest compatible versions
    Removing dtoa v0.4.0
    Updating itoa v0.3.0 -> v1.0.0 (available: v1.0.11)
    Updating plotters v0.3.1 -> v0.3.3 (available: v0.3.7)
    Removing quote v0.3.8
    Updating regex v1.5.0 -> v1.5.1 (available: v1.11.0)
    Updating serde v1.0.85 -> v1.0.166 (available: v1.0.210)
    Updating serde_derive v1.0.0 -> v1.0.166 (available: v1.0.210)
    Removing serde_derive_internals v0.15.0
    Updating serde_json v1.0.0 -> v1.0.100 (available: v1.0.132)
    Removing syn v0.11.10
    Removing synom v0.11.0
    Removing unicode-xid v0.0.4
note: pass `--verbose` to see 150 unchanged dependencies behind latest
cargo 1.82.0 (8f40fc59f 2024-08-21)
   Compiling proc-macro2 v1.0.75
   Compiling unicode-ident v1.0.0
   Compiling serde v1.0.166
   Compiling ryu v1.0.0
   Compiling serde_json v1.0.100
    Checking itoa v1.0.0
    Checking regex v1.5.1
    Checking plotters v0.3.3
   Compiling quote v1.0.35
   Compiling syn v2.0.52
   Compiling serde_derive v1.0.166
    Checking ciborium v0.2.0
    Checking tinytemplate v1.1.0
    Checking criterion v0.5.1 (/home/tfukaya/codes/criterion.rs)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 8.18s
```
