### PR TITLE
Introducing Criterion.rs Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@
     <a href="https://crates.io/crates/criterion">
         <img src="https://img.shields.io/crates/v/criterion.svg" alt="Crates.io">
     </a>
+    |
+    <a href="https://gurubase.io/g/criterion-rs">
+        <img src="https://img.shields.io/badge/Gurubase-Ask%20Criterion.rs%20Guru-006BFF" alt="Gurubase">
+    </a>
 </div>
 
 Criterion.<span></span>rs helps you write fast code by detecting and measuring performance improvements or regressions, even small ones, quickly and accurately. You can optimize with confidence, knowing how each change affects the performance of your code.


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Criterion.rs Guru](https://gurubase.io/g/criterion-rs) to Gurubase. Criterion.rs Guru uses the data from this repo and data from the [docs](https://bheisler.github.io/criterion.rs/book) to answer questions by leveraging the LLM.

In this PR, I showcased the "Criterion.rs Guru", which highlights that Criterion.rs now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Criterion.rs Guru in Gurubase, just let me know that's totally fine.
