### PR TITLE
Add Becnher.iter_reuse

### DIFF
--- a/tests/criterion_tests.rs
+++ b/tests/criterion_tests.rs
@@ -274,6 +274,9 @@ fn test_timing_loops() {
     let dir = temp_dir();
     let mut c = short_benchmark(&dir);
     let mut group = c.benchmark_group("test_timing_loops");
+    group.bench_function("iter_reuse", |b| {
+        b.iter_reuse(vec![10], |v| v);
+    });
     group.bench_function("iter_with_setup", |b| {
         b.iter_with_setup(|| vec![10], |v| v[0]);
     });


### PR DESCRIPTION
Hello! In my scenario for benchmarking asynchronous runtime, I needed to reuse a preallocated buffer that moved through several closures and was cleared after each start. 

It seemed to me that this feature is not currently supported natively in criterion, so I suggest my own version, in the hope that it will be useful to others. 

Thank you in advance!