### PR TITLE
Fixed plotting bug when all samples' measurements have the same value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 - MSRV bumped to 1.70
+- Fixed plotting bug when all samples' measurements have the same value. See [#720](https://github.com/bheisler/criterion.rs/issues/720).
 
 ### Changed
 - The `real_blackbox` feature no longer has any impact. Criterion always uses `std::hint::black_box()` now.

--- a/src/plot/gnuplot_backend/distributions.rs
+++ b/src/plot/gnuplot_backend/distributions.rs
@@ -68,7 +68,7 @@ fn abs_distribution(
         )))
         .configure(Axis::BottomX, |a| {
             a.set(Label(format!("Average time ({})", unit)))
-                .set(Range::Limits(kde_xs_sample.min(), kde_xs_sample.max()))
+                .set(Range::Auto)
         })
         .configure(Axis::LeftY, |a| a.set(Label("Density (a.u.)")))
         .configure(Key, |k| {

--- a/src/plot/gnuplot_backend/pdf.rs
+++ b/src/plot/gnuplot_backend/pdf.rs
@@ -237,7 +237,6 @@ pub(crate) fn pdf_small(
     let mean = scaled_avg_times.mean();
 
     let (xs, ys, mean_y) = kde::sweep_and_estimate(scaled_avg_times, KDE_POINTS, None, mean);
-    let xs_ = Sample::new(&xs);
     let ys_ = Sample::new(&ys);
 
     let y_limit = ys_.max() * 1.1;

--- a/src/plot/gnuplot_backend/pdf.rs
+++ b/src/plot/gnuplot_backend/pdf.rs
@@ -249,7 +249,7 @@ pub(crate) fn pdf_small(
         .set(size.unwrap_or(SIZE))
         .configure(Axis::BottomX, |a| {
             a.set(Label(format!("Average time ({})", unit)))
-                .set(Range::Limits(xs_.min(), xs_.max()))
+                .set(Range::Auto)
         })
         .configure(Axis::LeftY, |a| {
             a.set(Label("Density (a.u.)"))

--- a/src/plot/plotters_backend/distributions.rs
+++ b/src/plot/plotters_backend/distributions.rs
@@ -19,36 +19,52 @@ fn abs_distribution(
     let unit = formatter.scale_values(typical, &mut ci_values);
     let (lb, ub, point) = (ci_values[0], ci_values[1], ci_values[2]);
 
-    let start = lb - (ub - lb) / 9.;
-    let end = ub + (ub - lb) / 9.;
-    let mut scaled_xs: Vec<f64> = distribution.iter().cloned().collect();
-    let _ = formatter.scale_values(typical, &mut scaled_xs);
-    let scaled_xs_sample = Sample::new(&scaled_xs);
-    let (kde_xs, ys) = kde::sweep(scaled_xs_sample, KDE_POINTS, Some((start, end)));
+    let (kde_xs, ys, start, len, y_point) =
+    // If lower_bound == upper_bound, all samples have the same value.
+    // Here we make some tweaks for better visualization in the charts.
+    if lb == ub {
+        let delta = if lb == 0. { 0.01 } else { lb * 0.01 };
+        // the first two x,y values are to draw the line/bar of the distribution at `x`
+        // the second two x,y values are to draw the rectangle of the confidence interval
+        let kde_xs = Vec::from([lb, lb, lb - delta, lb + delta]).into_boxed_slice();
+        let ys = Vec::from([0_f64, point, point, point]).into_boxed_slice();
+        // start and len are used to mark the range of confidence interval rectangle coordinates
+        let start = 2_usize;
+        let len = 2_usize;
+        (kde_xs, ys, start, len, point)
+    } else {
+        let start = lb - (ub - lb) / 9.;
+        let end = ub + (ub - lb) / 9.;
+        let mut scaled_xs: Vec<f64> = distribution.iter().cloned().collect();
+        let _ = formatter.scale_values(typical, &mut scaled_xs);
+        let scaled_xs_sample = Sample::new(&scaled_xs);
+        let (kde_xs, ys) = kde::sweep(scaled_xs_sample, KDE_POINTS, Some((start, end)));
 
-    // interpolate between two points of the KDE sweep to find the Y position at the point estimate.
-    let n_point = kde_xs
-        .iter()
-        .position(|&x| x >= point)
-        .unwrap_or(kde_xs.len() - 1)
-        .max(1); // Must be at least the second element or this will panic
-    let slope = (ys[n_point] - ys[n_point - 1]) / (kde_xs[n_point] - kde_xs[n_point - 1]);
-    let y_point = ys[n_point - 1] + (slope * (point - kde_xs[n_point - 1]));
+        // interpolate between two points of the KDE sweep to find the Y position at the point estimate.
+        let n_point = kde_xs
+            .iter()
+            .position(|&x| x >= point)
+            .unwrap_or(kde_xs.len() - 1)
+            .max(1); // Must be at least the second element or this will panic
+        let slope = (ys[n_point] - ys[n_point - 1]) / (kde_xs[n_point] - kde_xs[n_point - 1]);
+        let y_point = ys[n_point - 1] + (slope * (point - kde_xs[n_point - 1]));
 
-    let start = kde_xs
-        .iter()
-        .enumerate()
-        .find(|&(_, &x)| x >= lb)
-        .unwrap()
-        .0;
-    let end = kde_xs
-        .iter()
-        .enumerate()
-        .rev()
-        .find(|&(_, &x)| x <= ub)
-        .unwrap()
-        .0;
-    let len = end - start;
+        let start = kde_xs
+            .iter()
+            .enumerate()
+            .find(|&(_, &x)| x >= lb)
+            .unwrap()
+            .0;
+        let end = kde_xs
+            .iter()
+            .enumerate()
+            .rev()
+            .find(|&(_, &x)| x <= ub)
+            .unwrap()
+            .0;
+        let len = end - start;
+        (kde_xs, ys, start, len, y_point)
+    };
 
     let kde_xs_sample = Sample::new(&kde_xs);
 

--- a/src/routine.rs
+++ b/src/routine.rs
@@ -104,8 +104,7 @@ pub(crate) trait Routine<M: Measurement, T: ?Sized> {
             // Early exit for extremely long running benchmarks:
             if time_start.elapsed() > maximum_bench_duration {
                 let iters = vec![n as f64, n as f64].into_boxed_slice();
-                // prevent gnuplot bug when all values are equal
-                let elapsed = vec![t_prev, t_prev + 0.000001].into_boxed_slice();
+                let elapsed = vec![t_prev, t_prev].into_boxed_slice();
                 return (ActualSamplingMode::Flat, iters, elapsed);
             }
 

--- a/src/stats/univariate/kde/mod.rs
+++ b/src/stats/univariate/kde/mod.rs
@@ -114,6 +114,20 @@ macro_rules! test {
             use crate::stats::univariate::kde::{Bandwidth, Kde};
             use crate::stats::univariate::Sample;
 
+            // The probability density of a sample when all sample
+            // values are the same X should be 1 for X.
+            #[test]
+            fn constant_sample_measurements() {
+                const CONSTANT_MEASUREMENT: $ty = 1.;
+                let measurements = &[CONSTANT_MEASUREMENT, CONSTANT_MEASUREMENT];
+                let sample = Sample::new(measurements);
+                let kde = Kde::new(sample, Gaussian, Bandwidth::Silverman);
+                for x in measurements {
+                    let prob_density = kde.estimate(*x);
+                    assert_eq!(prob_density, 1., "The probability density of X when all samples are X should be 1.");
+                }
+            }
+
             // The bandwidth should be a positive (non-zero) number, even when
             // the samples are all the same (constant measurements).
             // It's very unlikely that all samples will have the same value, but

--- a/src/stats/univariate/kde/mod.rs
+++ b/src/stats/univariate/kde/mod.rs
@@ -102,6 +102,19 @@ macro_rules! test {
             use crate::stats::univariate::kde::{Bandwidth, Kde};
             use crate::stats::univariate::Sample;
 
+            // The bandwidth should be a positive (non-zero) number, even when
+            // the samples are all the same (constant measurements).
+            // It's very unlikely that all samples will have the same value, but
+            // not impossible, so we should handle that case gracefully.
+            #[test]
+            fn positive_bandwidth() {
+                const CONSTANT_MEASUREMENT: $ty = 1.;
+                let sample = Sample::new(&[CONSTANT_MEASUREMENT, CONSTANT_MEASUREMENT]);
+                let bandwidth_estimator = Bandwidth::Silverman;
+                let h = bandwidth_estimator.estimate(&sample);
+                assert!(h > 0., "The bandwidth should be > 0, even when all samples have the same value, but it was 0.");
+            }
+
             // The [-inf inf] integral of the estimated PDF should be one
             quickcheck! {
                 fn integral(size: u8, start: u8) -> TestResult {

--- a/src/stats/univariate/kde/mod.rs
+++ b/src/stats/univariate/kde/mod.rs
@@ -84,7 +84,19 @@ impl Bandwidth {
                 let n = A::cast(sample.len());
                 let sigma = sample.std_dev(None);
 
-                sigma * (factor / n).powf(exponent)
+                // When all samples have the same value (rare case, but not impossible),
+                // the standard deviation will be zero, and the Silverman
+                // method will produce a zeroed bandwidth.
+                // But the bandwidth should always be a positive (non-zero) number,
+                // so if that happens, the optimal bandwidth should be very small,
+                // as this will create a very sharp peak at the single data point,
+                // accurately reflecting the fact that all data is concentrated
+                // at that single value.
+                if sigma.is_zero() {
+                    A::cast(0.001)
+                } else {
+                    sigma * (factor / n).powf(exponent)
+                }
             }
         }
     }

--- a/tests/criterion_tests.rs
+++ b/tests/criterion_tests.rs
@@ -275,7 +275,9 @@ fn test_timing_loops() {
         use criterion::PlottingBackend::*;
         [
             None,
+            #[cfg(feature = "html_reports")]
             Gnuplot,
+            #[cfg(feature = "html_reports")]
             #[cfg(feature = "plotters")]
             Plotters,
         ]

--- a/tests/criterion_tests.rs
+++ b/tests/criterion_tests.rs
@@ -271,48 +271,69 @@ fn test_filtering() {
 
 #[test]
 fn test_timing_loops() {
-    let dir = temp_dir();
-    let mut c = short_benchmark(&dir);
-    let mut group = c.benchmark_group("test_timing_loops");
-    group.bench_function("iter_with_setup", |b| {
-        b.iter_with_setup(|| vec![10], |v| v[0]);
-    });
-    group.bench_function("iter_with_large_setup", |b| {
-        b.iter_batched(|| vec![10], |v| v[0], BatchSize::NumBatches(1));
-    });
-    group.bench_function("iter_with_large_drop", |b| {
-        b.iter_with_large_drop(|| vec![10; 100]);
-    });
-    group.bench_function("iter_batched_small", |b| {
-        b.iter_batched(|| vec![10], |v| v[0], BatchSize::SmallInput);
-    });
-    group.bench_function("iter_batched_large", |b| {
-        b.iter_batched(|| vec![10], |v| v[0], BatchSize::LargeInput);
-    });
-    group.bench_function("iter_batched_per_iteration", |b| {
-        b.iter_batched(|| vec![10], |v| v[0], BatchSize::PerIteration);
-    });
-    group.bench_function("iter_batched_one_batch", |b| {
-        b.iter_batched(|| vec![10], |v| v[0], BatchSize::NumBatches(1));
-    });
-    group.bench_function("iter_batched_10_iterations", |b| {
-        b.iter_batched(|| vec![10], |v| v[0], BatchSize::NumIterations(10));
-    });
-    group.bench_function("iter_batched_ref_small", |b| {
-        b.iter_batched_ref(|| vec![10], |v| v[0], BatchSize::SmallInput);
-    });
-    group.bench_function("iter_batched_ref_large", |b| {
-        b.iter_batched_ref(|| vec![10], |v| v[0], BatchSize::LargeInput);
-    });
-    group.bench_function("iter_batched_ref_per_iteration", |b| {
-        b.iter_batched_ref(|| vec![10], |v| v[0], BatchSize::PerIteration);
-    });
-    group.bench_function("iter_batched_ref_one_batch", |b| {
-        b.iter_batched_ref(|| vec![10], |v| v[0], BatchSize::NumBatches(1));
-    });
-    group.bench_function("iter_batched_ref_10_iterations", |b| {
-        b.iter_batched_ref(|| vec![10], |v| v[0], BatchSize::NumIterations(10));
-    });
+    let plotting_backends = {
+        use criterion::PlottingBackend::*;
+        [
+            None,
+            Gnuplot,
+            #[cfg(feature = "plotters")]
+            Plotters,
+        ]
+    };
+    for plotting_backend in plotting_backends {
+        let dir = temp_dir();
+        let mut c = short_benchmark(&dir).plotting_backend(plotting_backend);
+        let mut group = c.benchmark_group("test_timing_loops");
+        group.bench_function("iter_with_setup", |b| {
+            b.iter_with_setup(|| vec![10], |v| v[0]);
+        });
+        group.bench_function("iter_with_large_setup", |b| {
+            b.iter_batched(|| vec![10], |v| v[0], BatchSize::NumBatches(1));
+        });
+        group.bench_function("iter_with_large_drop", |b| {
+            b.iter_with_large_drop(|| vec![10; 100]);
+        });
+        group.bench_function("iter_batched_small", |b| {
+            b.iter_batched(|| vec![10], |v| v[0], BatchSize::SmallInput);
+        });
+        group.bench_function("iter_batched_large", |b| {
+            b.iter_batched(|| vec![10], |v| v[0], BatchSize::LargeInput);
+        });
+        group.bench_function("iter_batched_per_iteration", |b| {
+            b.iter_batched(|| vec![10], |v| v[0], BatchSize::PerIteration);
+        });
+        group.bench_function("iter_batched_one_batch", |b| {
+            b.iter_batched(|| vec![10], |v| v[0], BatchSize::NumBatches(1));
+        });
+        group.bench_function("iter_batched_10_iterations", |b| {
+            b.iter_batched(|| vec![10], |v| v[0], BatchSize::NumIterations(10));
+        });
+        group.bench_function("iter_batched_ref_small", |b| {
+            b.iter_batched_ref(|| vec![10], |v| v[0], BatchSize::SmallInput);
+        });
+        group.bench_function("iter_batched_ref_large", |b| {
+            b.iter_batched_ref(|| vec![10], |v| v[0], BatchSize::LargeInput);
+        });
+        group.bench_function("iter_batched_ref_per_iteration", |b| {
+            b.iter_batched_ref(|| vec![10], |v| v[0], BatchSize::PerIteration);
+        });
+        group.bench_function("iter_batched_ref_one_batch", |b| {
+            b.iter_batched_ref(|| vec![10], |v| v[0], BatchSize::NumBatches(1));
+        });
+        group.bench_function("iter_batched_ref_10_iterations", |b| {
+            b.iter_batched_ref(|| vec![10], |v| v[0], BatchSize::NumIterations(10));
+        });
+        group.bench_function("iter_custom_const_total_duration", |b| {
+            b.iter_custom(|_iter| Duration::from_nanos(1))
+        });
+        #[allow(
+            clippy::redundant_closure,
+            reason = "Keep the 'iter' variable visible for clarity."
+        )]
+        group.bench_function("iter_custom_const_iter_duration", |b| {
+            b.iter_custom(|iter| Duration::from_nanos(iter))
+        });
+    }
 }
 
 // Verify that all expected output files are present


### PR DESCRIPTION
This PR fixes #720.

## Overview of the bug

**Criterion** `panics` when generating PDF plots with `gnuplot` or `plotters` and all measurements in a sample have the same duration.

## Root cause

1. The root cause is that the [KDE bandwidth estimation](https://github.com/bheisler/criterion.rs/blob/260e2f1c788227096cf483c0c2a1933968bbe27b/src/stats/univariate/kde/mod.rs#L85) returns zero (because the standard deviation is zero) when all measurements in a sample have the same value
2. That causes a division by zero error (`NaN`) in the [KDE's probability density estimation](https://github.com/bheisler/criterion.rs/blob/260e2f1c788227096cf483c0c2a1933968bbe27b/src/stats/univariate/kde/mod.rs#L66) (`(... / h)` when `h==0`)
3. That causes an assertion panic `assertion failed: slice.len() > 1 && slice.iter().all(|x| !x.is_nan())` when [initializing a Sample](https://github.com/bheisler/criterion.rs/blob/260e2f1c788227096cf483c0c2a1933968bbe27b/src/stats/univariate/sample.rs#L31).

## When does it happen?

There are mainly 3 scenarios in which all samples have the same duration:

1. When Criterion aborts extremely long running benchmarks and create a sample with two "identical values", in which existing [hack to prevent `gnuplot` bug](https://github.com/bheisler/criterion.rs/blob/260e2f1c788227096cf483c0c2a1933968bbe27b/src/routine.rs#L108) may fail #720.
2. When the developer returns the same duration per iteration in a `iter_custom` benchmark (for example, when the having a custom logic that sets a minimum value for the duration to be, useful when comparing *O(1)* and *O(n)* functions).
3. By pure, and almost impossible, chance when multiple measurements are the same at the nanosecond level.

## Changes

This PR fixes the root cause of the bug and slightly improves the plotting of PDF charts when all measurements in a sample have the same value.

1. First we increase the test coverage to reproduce the error: d94aad7 and cf44f55
2. Then we add a test case for the bandwidth estimation 21d5353
3. We fix the bug in the bandwidth estimation ca6f1bc
4. Then we add a test case for the KDE estimation e160bed
5. We fix the bug in the KDE estimation 0937444
6. We also fix the error `Gnuplot:Can't plot with an empty x range!` 7cf32eb
7. And finally we improve the plot of PDF charts for this scenario b2279f3
    Before:
    <img width="600" alt="image" src="https://github.com/user-attachments/assets/8a3e0c34-a458-4948-af9c-0dc9fe7f69b5">
    After:
    <img width="600" alt="image" src="https://github.com/user-attachments/assets/7bd0d6f3-aaea-4012-8193-424d21bed1ab">
