### PR TITLE
support throughput reports in bits

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1275,6 +1275,11 @@ pub enum Throughput {
     /// collection, but could also be the number of lines of input text or the number of values to
     /// parse.
     Elements(u64),
+
+    /// Measure throughput in terms of bits/second. The value should be the number of bits
+    /// processed by one iteration of the benchmarked code. Typically, this would be the number of
+    /// bits transferred by a networking function.
+    Bits(u64),
 }
 
 /// Axis scaling type. Specified via [`PlotConfiguration::summary_scale`].

--- a/src/measurement.rs
+++ b/src/measurement.rs
@@ -166,6 +166,26 @@ impl DurationFormatter {
 
         unit
     }
+
+    fn bits_per_second(&self, bits: f64, typical: f64, values: &mut [f64]) -> &'static str {
+        let bits_per_second = bits * (1e9 / typical);
+        let (denominator, unit) = if bits_per_second < 1000.0 {
+            (1.0, "  b/s")
+        } else if bits_per_second < 1000.0 * 1000.0 {
+            (1000.0, "Kb/s")
+        } else if bits_per_second < 1000.0 * 1000.0 * 1000.0 {
+            (1000.0 * 1000.0, "Mb/s")
+        } else {
+            (1000.0 * 1000.0 * 1000.0, "Gb/s")
+        };
+
+        for val in values {
+            let bits_per_second = bits * (1e9 / *val);
+            *val = bits_per_second / denominator;
+        }
+
+        unit
+    }
 }
 impl ValueFormatter for DurationFormatter {
     fn scale_throughputs(
@@ -180,6 +200,7 @@ impl ValueFormatter for DurationFormatter {
                 self.bytes_per_second_decimal(bytes as f64, typical, values)
             }
             Throughput::Elements(elems) => self.elements_per_second(elems as f64, typical, values),
+            Throughput::Bits(bits) => self.bits_per_second(bits as f64, typical, values),
         }
     }
 

--- a/src/plot/gnuplot_backend/summary.rs
+++ b/src/plot/gnuplot_backend/summary.rs
@@ -47,6 +47,7 @@ pub fn line_comparison(
     let input_suffix = match value_type {
         ValueType::Bytes => " Size (Bytes)",
         ValueType::Elements => " Size (Elements)",
+        ValueType::Bits => " Size (Bits)",
         ValueType::Value => "",
     };
 

--- a/src/plot/plotters_backend/summary.rs
+++ b/src/plot/plotters_backend/summary.rs
@@ -68,6 +68,7 @@ fn draw_line_comarision_figure<XR: AsRangedCoord<Value = f64>, YR: AsRangedCoord
     let input_suffix = match value_type {
         ValueType::Bytes => " Size (Bytes)",
         ValueType::Elements => " Size (Elements)",
+        ValueType::Bits => " Size (Bits)",
         ValueType::Value => "",
     };
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -59,6 +59,7 @@ impl<'a> MeasurementData<'a> {
 pub enum ValueType {
     Bytes,
     Elements,
+    Bits,
     Value,
 }
 
@@ -176,7 +177,8 @@ impl BenchmarkId {
         match self.throughput {
             Some(Throughput::Bytes(n))
             | Some(Throughput::Elements(n))
-            | Some(Throughput::BytesDecimal(n)) => Some(n as f64),
+            | Some(Throughput::BytesDecimal(n))
+            | Some(Throughput::Bits(n)) => Some(n as f64),
             None => self
                 .value_str
                 .as_ref()
@@ -189,6 +191,7 @@ impl BenchmarkId {
             Some(Throughput::Bytes(_)) => Some(ValueType::Bytes),
             Some(Throughput::BytesDecimal(_)) => Some(ValueType::Bytes),
             Some(Throughput::Elements(_)) => Some(ValueType::Elements),
+            Some(Throughput::Bits(_)) => Some(ValueType::Bits),
             None => self
                 .value_str
                 .as_ref()


### PR DESCRIPTION
Closes #630 

example:
```
Benchmarking Proxy/throughput: Warming up for 3.0000 s
Proxy/throughput
                    time:   [927.55 ms 965.78 ms 1.0286 s]
                    thrpt:  [7.7778 Gb/s 8.2835 Gb/s 8.6249 Gb/s]
             change:
                    time:   [−3.6708% +1.7313% +8.7592%] (p = 0.70 > 0.05)
                    thrpt:  [−8.0537% −1.7018% +3.8107%]
                    No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
```