### PR TITLE
Using black_box in comparing_functions.md

### DIFF
--- a/book/src/user_guide/comparing_functions.md
+++ b/book/src/user_guide/comparing_functions.md
@@ -38,9 +38,9 @@ fn bench_fibs(c: &mut Criterion) {
     let mut group = c.benchmark_group("Fibonacci");
     for i in [20u64, 21u64].iter() {
         group.bench_with_input(BenchmarkId::new("Recursive", i), i, 
-            |b, i| b.iter(|| fibonacci_slow(*i)));
+            |b, i| b.iter(|| fibonacci_slow(black_box(*i))));
         group.bench_with_input(BenchmarkId::new("Iterative", i), i, 
-            |b, i| b.iter(|| fibonacci_fast(*i)));
+            |b, i| b.iter(|| fibonacci_fast(black_box(*i))));
     }
     group.finish();
 }


### PR DESCRIPTION
Hello,

Here's a fix for the documentation, specifically to the `comparing function` part.
FTR I was confused at my local results until I remembered about the black_box role.

I also noticed the doc was updated to use the black_box in the 2nd code snippet, but [the website](https://bheisler.github.io/criterion.rs/book/user_guide/comparing_functions.html) is not updated for a long time? At least since this [PR](https://github.com/bheisler/criterion.rs/commit/1b7ca528beaff4e6f0e07368a1058726df32695f) was merged.

edit: related issue regarding the book not being published https://github.com/bheisler/criterion.rs/issues/815