### PR TITLE
Add CI job checking library builds with oldest allowed dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,7 @@ on:
 name: tests
 env:
   CARGO_TERM_COLOR: always
+  MSRV: 1.80.0
 
 jobs:
   ci:
@@ -19,7 +20,7 @@ jobs:
       matrix:
         rust:
           - 1.87.0 # Stable release as of 2025-05-17
-          - 1.80.0 # MSRV
+          - $MSRV # MSRV
 
     steps:
       - uses: actions/checkout@v4
@@ -110,11 +111,11 @@ jobs:
 
       - name: Install needed Rust toolchain versions
         run: |
-          rustup install stable
+          rustup install $MSRV
           rustup install nightly
 
       - name: Downgrade dependencies to minimal versions
         run: cargo +nightly update -Z minimal-versions
 
       - name: Compile with minimal versions
-        run: cargo +stable build --all-targets --locked
+        run: cargo +$MSRV build --all-targets --locked

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,3 +98,23 @@ jobs:
 
       - name: check typos
         uses: crate-ci/typos@v1.23.5
+
+
+  # Make sure the library builds with all dependencies downgraded to their
+  # oldest versions allowed by the semver spec. This ensures we have not
+  # under-specified any dependency
+  minimal-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install needed Rust toolchain versions
+        run: |
+          rustup install stable
+          rustup install nightly
+
+      - name: Downgrade dependencies to minimal versions
+        run: cargo +nightly update -Z minimal-versions
+
+      - name: Compile with minimal versions
+        run: cargo +stable build --all-targets --locked

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ name = "criterion"
 # * Update version numbers in the book;
 version = "0.6.0"
 edition = "2021"
+# Update the MSRV variable in .github/workflows/ci.yml when changing this.
 rust-version = "1.80"
 
 description = "Statistics-driven micro-benchmarking library"


### PR DESCRIPTION
Prevents under-specifying our dependencies. Ensure the semver specs we write in our Cargo.toml are not allowing older versions than we actually build with. Catches issues such as the ones fixed in #821 before they are merged.

This type of check seems to have been present in the past, but removed at some point.

The current latest release `0.5.1` does not build with all dependencies downgraded to their oldest allowed versions. This is currently causing a bit of trouble for me. So I want to help by contributing a CI to check for this. I also hope a new release can be cut soon, since the issue has been fixed on `master` :pray: 