### PR TITLE
Fix warnings from clippy (rust 1.87.0)

### DIFF
--- a/plot/src/axis.rs
+++ b/plot/src/axis.rs
@@ -153,7 +153,7 @@ where
     }
 }
 
-impl<'a> Script for (Axis, &'a Properties) {
+impl Script for (Axis, &Properties) {
     fn script(&self) -> String {
         let &(axis, properties) = self;
         let axis_ = axis.display();

--- a/plot/src/grid.rs
+++ b/plot/src/grid.rs
@@ -31,7 +31,7 @@ impl Properties {
     }
 }
 
-impl<'a> Script for (Axis, Grid, &'a Properties) {
+impl Script for (Axis, Grid, &Properties) {
     fn script(&self) -> String {
         let &(axis, grid, properties) = self;
         let axis = axis.display();

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -111,7 +111,7 @@ pub(crate) fn common<M: Measurement, T: ?Sized>(
 
     criterion.report.analysis(id, report_context);
 
-    if times.iter().any(|&f| f == 0.0) {
+    if times.contains(&0.0) {
         error!(
             "At least one measurement of benchmark {} took zero time per \
             iteration. This should not be possible. If using iter_custom, please verify \

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -939,7 +939,7 @@ https://bheisler.github.io/criterion.rs/book/faq.html
             if matches.contains_id("baseline")
                 || matches
                     .get_one::<String>("save-baseline")
-                    .map_or(false, |base| base != "base")
+                    .is_some_and(|base| base != "base")
                 || matches.contains_id("load-baseline")
             {
                 eprintln!("Error: baselines are not supported when running with cargo-criterion.");

--- a/src/stats/univariate/outliers/tukey.rs
+++ b/src/stats/univariate/outliers/tukey.rs
@@ -153,7 +153,7 @@ where
     }
 }
 
-impl<'a, 'b, A> IntoIterator for &'b LabeledSample<'a, A>
+impl<'a, A> IntoIterator for &LabeledSample<'a, A>
 where
     A: Float,
 {

--- a/src/stats/univariate/percentiles.rs
+++ b/src/stats/univariate/percentiles.rs
@@ -20,7 +20,7 @@ where
     unsafe fn at_unchecked(&self, p: A) -> A {
         let _100 = A::cast(100);
         debug_assert!(p >= A::cast(0) && p <= _100);
-        debug_assert!(self.0.len() > 0);
+        debug_assert!(!self.0.is_empty());
         let len = self.0.len() - 1;
 
         if p == _100 {
@@ -47,7 +47,7 @@ where
         let _100 = A::cast(100);
 
         assert!(p >= _0 && p <= _100);
-        assert!(self.0.len() > 0);
+        assert!(!self.0.is_empty());
 
         unsafe { self.at_unchecked(p) }
     }


### PR DESCRIPTION
The CI currently fails against the `master` branch, since latest clippy has a few warnings that this code base has not yet accounted for. This PR fixes that, so the code is lint warning free, and CI should be green again (when #855 is also merged. They will block each other)