### PR TITLE
Monomorphize `Routine`

### DIFF
--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -36,9 +36,9 @@ macro_rules! elapsed {
 mod compare;
 
 // Common analysis procedure
-pub(crate) fn common<M: Measurement, T: ?Sized>(
+pub(crate) fn common<M: Measurement, T: ?Sized, R: Routine<M, T> + ?Sized>(
     id: &BenchmarkId,
-    routine: &mut dyn Routine<M, T>,
+    routine: &mut R,
     config: &BenchmarkConfig,
     criterion: &Criterion<M>,
     report_context: &ReportContext,


### PR DESCRIPTION
Currently, calling `{Criterion,BenchmarkGroup}::bench_function` creates a copy of `BenchmarkGroup::run_bench`, which includes all the `Routine` trait methods, for every unique bench closure. This is unnecessary and doesn't make a difference for benchmark performance as the closure in question is the one taking `&mut Bencher`, which is not the actual routine that is timed.

This PR roughly halves the number of LLVM lines generated by the Rust compiler, tested with [`recmo/uint`](https://github.com/recmo/uint)'s benchmarking suite using `cargo llvm-lines -p ruint --bench bench_uint`. This suite has around 214 unique calls to `criterion.bench_function`. This speeds up compilation of a release build of the benchmark from ~15s to ~12s on my machine, likely a lot more in more resource-constrained environments like in CI, or when using less codegen-units.

Before:
```text
  Lines                 Copies               Function name
  -----                 ------               -------------
  911857                26592                (TOTAL)
```

After:
```text
  Lines                 Copies               Function name
  -----                 ------               -------------
  413095                15305                (TOTAL)
```