### PR TITLE
refactor: replace `futures` with `futures-executor`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "csv",
- "futures",
+ "futures-executor",
  "itertools",
  "num-traits",
  "oorandom",
@@ -488,28 +488,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "futures"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -549,23 +533,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-macro"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
-
-[[package]]
 name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -577,13 +544,8 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
- "futures-macro",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,9 +51,7 @@ regex = { version = "1.5.1", default-features = false, features = ["std"] }
 # Optional dependencies
 rayon = { version = "1.3", optional = true }
 csv = { version = "1.1", optional = true }
-futures = { version = "0.3", default-features = false, features = [
-    "executor",
-], optional = true }
+futures-executor = { version = "0.3", optional = true }
 smol = { version = "2.0", default-features = false, optional = true }
 tokio = { version = "1.0", default-features = false, features = [
     "rt",
@@ -71,7 +69,6 @@ tempfile = "3.5.0"
 approx = "0.5.0"
 quickcheck = { version = "1.0", default-features = false }
 rand = "0.8"
-futures = "0.3"
 
 [badges]
 maintenance = { status = "passively-maintained" }
@@ -101,7 +98,7 @@ async = []
 
 # These features enable built-in support for running async benchmarks on each different async
 # runtime.
-async_futures = ["dep:futures", "async"]
+async_futures = ["dep:futures-executor", "async"]
 async_smol = ["dep:smol", "async"]
 async_tokio = ["dep:tokio", "async"]
 async_std = ["dep:async-std", "async"]

--- a/src/async_executor.rs
+++ b/src/async_executor.rs
@@ -28,7 +28,7 @@ pub struct FuturesExecutor;
 #[cfg(feature = "async_futures")]
 impl AsyncExecutor for FuturesExecutor {
     fn block_on<T>(&self, future: impl Future<Output = T>) -> T {
-        futures::executor::block_on(future)
+        futures_executor::block_on(future)
     }
 }
 


### PR DESCRIPTION
Criterion only uses `futures::executor::block_on`, so we can replace `futures` with `futures-executor` and get a smaller dependency tree.