### PR TITLE
Remove `itertools` dependency from the main crate.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,7 +358,6 @@ dependencies = [
  "criterion-plot",
  "csv",
  "futures",
- "itertools",
  "num-traits",
  "oorandom",
  "plotters",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ exclude     = ["book/*"]
 [dependencies]
 anes           = "0.1.4"
 criterion-plot = { path = "plot", version = "0.5.0" }
-itertools      = "0.13"
 serde          = { version = "1.0.100", features = ["derive"] }
 serde_json     = "1.0.100"
 ciborium       = "0.2.0"

--- a/src/plot/gnuplot_backend/summary.rs
+++ b/src/plot/gnuplot_backend/summary.rs
@@ -6,7 +6,6 @@ use crate::report::{BenchmarkId, ValueType};
 use crate::stats::univariate::Sample;
 use crate::AxisScale;
 use criterion_plot::prelude::*;
-use itertools::Itertools;
 use std::cmp::Ordering;
 use std::path::{Path, PathBuf};
 use std::process::Child;
@@ -84,8 +83,11 @@ pub fn line_comparison(
     // This assumes the curves are sorted. It also assumes that the benchmark IDs all have numeric
     // values or throughputs and that value is sensible (ie. not a mix of bytes and elements
     // or whatnot)
-    for (key, group) in &all_curves.iter().chunk_by(|&&&(id, _)| &id.function_id) {
+    for group in all_curves.chunk_by(|(a_id, _), (b_id, _)| a_id.function_id == b_id.function_id) {
+        let key = &group[0].0.function_id;
+
         let mut tuples: Vec<_> = group
+            .iter()
             .map(|&&(id, ref sample)| {
                 // Unwrap is fine here because it will only fail if the assumptions above are not true
                 // ie. programmer error.

--- a/src/plot/plotters_backend/summary.rs
+++ b/src/plot/plotters_backend/summary.rs
@@ -1,6 +1,5 @@
 use super::*;
 use crate::AxisScale;
-use itertools::Itertools;
 use plotters::coord::{
     ranged1d::{AsRangedCoord, ValueFormatter as PlottersValueFormatter},
     Shift,
@@ -132,8 +131,11 @@ fn line_comparison_series_data<'a>(
     // This assumes the curves are sorted. It also assumes that the benchmark IDs all have numeric
     // values or throughputs and that value is sensible (ie. not a mix of bytes and elements
     // or whatnot)
-    for (key, group) in &all_curves.iter().chunk_by(|&&&(id, _)| &id.function_id) {
+    for group in all_curves.chunk_by(|(a_id, _), (b_id, _)| a_id.function_id == b_id.function_id) {
+        let key = &group[0].0.function_id;
+
         let mut tuples: Vec<_> = group
+            .iter()
             .map(|&&(id, ref sample)| {
                 // Unwrap is fine here because it will only fail if the assumptions above are not true
                 // ie. programmer error.


### PR DESCRIPTION
`[T]::chunk_by` is stable as of Rust 1.77.