### PR TITLE
Remove itertools dependency from the main crate and from the plot crate.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,8 +379,6 @@ name = "criterion-plot"
 version = "0.5.0"
 dependencies = [
  "cast",
- "itertools",
- "itertools-num",
  "num-complex",
  "rand",
 ]
@@ -644,24 +642,6 @@ name = "hermit-abi"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools-num"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a872a22f9e6f7521ca557660adb96dd830e54f0f490fa115bb55dd69d38b27e7"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "itoa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,7 +358,6 @@ dependencies = [
  "criterion-plot",
  "csv",
  "futures",
- "itertools",
  "num-traits",
  "oorandom",
  "plotters",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ exclude     = ["book/*"]
 [dependencies]
 anes           = "0.1.4"
 criterion-plot = { path = "plot", version = "0.5.0" }
-itertools      = "0.13"
 serde          = { version = "1.0.100", features = ["derive"] }
 serde_json     = "1.0.100"
 ciborium       = "0.2.0"

--- a/plot/Cargo.toml
+++ b/plot/Cargo.toml
@@ -13,10 +13,8 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 cast = "0.3"
-itertools = "0.13"
 
 [dev-dependencies]
-itertools-num = "0.1"
 num-complex = { version = "0.4", default-features = false, features = ["std"] }
 rand = "0.8"
 

--- a/plot/src/candlestick.rs
+++ b/plot/src/candlestick.rs
@@ -3,6 +3,7 @@
 use std::borrow::Cow;
 
 use crate::data::Matrix;
+use crate::itertools_mini::zip5;
 use crate::traits::{self, Data, Set};
 use crate::{Color, Default, Display, Figure, Label, LineType, LineWidth, Plot, Script};
 
@@ -140,7 +141,7 @@ where
         } = candlesticks;
 
         let data = Matrix::new(
-            itertools::izip!(x, box_min, whisker_min, whisker_high, box_high),
+            zip5(x, box_min, whisker_min, whisker_high, box_high),
             (x_factor, y_factor, y_factor, y_factor, y_factor),
         );
         self.plots

--- a/plot/src/curve.rs
+++ b/plot/src/curve.rs
@@ -262,7 +262,7 @@ where
         let (x_factor, y_factor) =
             crate::scale_factor(&self.axes, props.axes.unwrap_or(crate::Axes::BottomXLeftY));
 
-        let data = Matrix::new(itertools::izip!(x, y), (x_factor, y_factor));
+        let data = Matrix::new(x.into_iter().zip(y), (x_factor, y_factor));
         self.plots.push(Plot::new(data, &props));
         self
     }

--- a/plot/src/errorbar.rs
+++ b/plot/src/errorbar.rs
@@ -3,6 +3,7 @@
 use std::borrow::Cow;
 
 use crate::data::Matrix;
+use crate::itertools_mini::zip4;
 use crate::traits::{self, Data, Set};
 use crate::{
     Color, Display, ErrorBarDefault, Figure, Label, LineType, LineWidth, Plot, PointSize,
@@ -259,7 +260,7 @@ where
             } => (x, y, y_low, y_high, y_factor),
         };
         let data = Matrix::new(
-            itertools::izip!(x, y, length, height),
+            zip4(x, y, length, height),
             (x_factor, y_factor, e_factor, e_factor),
         );
         self.plots.push(Plot::new(

--- a/plot/src/filledcurve.rs
+++ b/plot/src/filledcurve.rs
@@ -3,6 +3,7 @@
 use std::borrow::Cow;
 
 use crate::data::Matrix;
+use crate::itertools_mini::zip3;
 use crate::traits::{self, Data, Set};
 use crate::{Axes, Color, Default, Display, Figure, Label, Opacity, Plot, Script};
 
@@ -132,7 +133,7 @@ where
         let (x_factor, y_factor) =
             crate::scale_factor(&self.axes, props.axes.unwrap_or(crate::Axes::BottomXLeftY));
 
-        let data = Matrix::new(itertools::izip!(x, y1, y2), (x_factor, y_factor, y_factor));
+        let data = Matrix::new(zip3(x, y1, y2), (x_factor, y_factor, y_factor));
         self.plots.push(Plot::new(data, &props));
         self
     }

--- a/plot/src/itertools_mini.rs
+++ b/plot/src/itertools_mini.rs
@@ -1,0 +1,35 @@
+pub fn zip3<A: IntoIterator, B: IntoIterator, C: IntoIterator>(
+    a: A,
+    b: B,
+    c: C,
+) -> impl Iterator<Item = (A::Item, B::Item, C::Item)> {
+    a.into_iter().zip(b).zip(c).map(|((a, b), c)| (a, b, c))
+}
+
+pub fn zip4<A: IntoIterator, B: IntoIterator, C: IntoIterator, D: IntoIterator>(
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+) -> impl Iterator<Item = (A::Item, B::Item, C::Item, D::Item)> {
+    a.into_iter()
+        .zip(b)
+        .zip(c)
+        .zip(d)
+        .map(|(((a, b), c), d)| (a, b, c, d))
+}
+
+pub fn zip5<A: IntoIterator, B: IntoIterator, C: IntoIterator, D: IntoIterator, E: IntoIterator>(
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+) -> impl Iterator<Item = (A::Item, B::Item, C::Item, D::Item, E::Item)> {
+    a.into_iter()
+        .zip(b)
+        .zip(c)
+        .zip(d)
+        .zip(e)
+        .map(|((((a, b), c), d), e)| (a, b, c, d, e))
+}

--- a/plot/src/lib.rs
+++ b/plot/src/lib.rs
@@ -391,6 +391,7 @@ pub mod curve;
 pub mod errorbar;
 pub mod filledcurve;
 pub mod grid;
+mod itertools_mini;
 pub mod key;
 pub mod prelude;
 pub mod proxy;

--- a/src/itertools_mini.rs
+++ b/src/itertools_mini.rs
@@ -1,0 +1,14 @@
+pub fn chunk_by<'c, T, Key: 'c + Copy + Eq>(
+    c: &'c [T],
+    by: impl Copy + for<'a> Fn(&'a T) -> Key,
+) -> impl Iterator<Item = (Key, &'c [T])> {
+    c.chunk_by(move |a, b| {
+        let a_key = by(a);
+        let b_key = by(b);
+        a_key == b_key
+    })
+    .map(move |chunk| {
+        let key = by(&chunk[0]); // Chunks are never empty.
+        (key, chunk)
+    })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,7 @@ mod estimate;
 mod format;
 mod fs;
 mod html;
+mod itertools_mini;
 mod kde;
 mod macros;
 pub mod measurement;

--- a/src/plot/gnuplot_backend/summary.rs
+++ b/src/plot/gnuplot_backend/summary.rs
@@ -1,12 +1,12 @@
 use super::{debug_script, gnuplot_escape};
 use super::{DARK_BLUE, DEFAULT_FONT, KDE_POINTS, LINEWIDTH, POINT_SIZE, SIZE};
+use crate::itertools_mini::chunk_by;
 use crate::kde;
 use crate::measurement::ValueFormatter;
 use crate::report::{BenchmarkId, ValueType};
 use crate::stats::univariate::Sample;
 use crate::AxisScale;
 use criterion_plot::prelude::*;
-use itertools::Itertools;
 use std::cmp::Ordering;
 use std::path::{Path, PathBuf};
 use std::process::Child;
@@ -84,8 +84,9 @@ pub fn line_comparison(
     // This assumes the curves are sorted. It also assumes that the benchmark IDs all have numeric
     // values or throughputs and that value is sensible (ie. not a mix of bytes and elements
     // or whatnot)
-    for (key, group) in &all_curves.iter().chunk_by(|&&&(id, _)| &id.function_id) {
+    for (key, group) in chunk_by(all_curves, |&&(id, _)| &id.function_id) {
         let mut tuples: Vec<_> = group
+            .iter()
             .map(|&&(id, ref sample)| {
                 // Unwrap is fine here because it will only fail if the assumptions above are not true
                 // ie. programmer error.

--- a/src/plot/plotters_backend/summary.rs
+++ b/src/plot/plotters_backend/summary.rs
@@ -1,6 +1,6 @@
 use super::*;
+use crate::itertools_mini::chunk_by;
 use crate::AxisScale;
-use itertools::Itertools;
 use plotters::coord::{
     ranged1d::{AsRangedCoord, ValueFormatter as PlottersValueFormatter},
     Shift,
@@ -132,8 +132,9 @@ fn line_comparison_series_data<'a>(
     // This assumes the curves are sorted. It also assumes that the benchmark IDs all have numeric
     // values or throughputs and that value is sensible (ie. not a mix of bytes and elements
     // or whatnot)
-    for (key, group) in &all_curves.iter().chunk_by(|&&&(id, _)| &id.function_id) {
+    for (key, group) in chunk_by(&all_curves, |&&(id, _)| &id.function_id) {
         let mut tuples: Vec<_> = group
+            .iter()
             .map(|&&(id, ref sample)| {
                 // Unwrap is fine here because it will only fail if the assumptions above are not true
                 // ie. programmer error.


### PR DESCRIPTION
Only `chunk_by` and `izip!` are used, and it is easy to replace both, to avoid the dependency.