### PR TITLE
feat(analysis): hint at --baseline-lenient in baseline panic

### DIFF
--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -54,7 +54,7 @@ pub(crate) fn common<M: Measurement, T: ?Sized>(
             &criterion.output_directory,
         ) {
             panic!(
-                "Baseline '{base}' must exist before comparison is allowed; try --save-baseline {base}",
+                "Baseline '{base}' must exist before comparison is allowed; try --save-baseline {base} or --baseline-lenient",
                 base=criterion.baseline_directory,
             );
         }


### PR DESCRIPTION
https://github.com/bheisler/criterion.rs/pull/532 introduced the `--baseline-lenient` flag.

Given a missing baseline with `--baseline`, hint at the `--baseline-lenient` flag.