### PR TITLE
Fix test badge repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 <div align="center">
  <a href="https://github.com/bheisler/criterion.rs/actions/workflows/ci.yaml">
-        <img src="https://img.shields.io/github/checks-status/rgeometry/rgeometry/main?label=tests&logo=github" alt="GitHub branch checks state">
+        <img src="https://img.shields.io/github/checks-status/bheisler/criterion.rs/master?logo=github&label=tests" alt="GitHub branch checks state">
     </a>
     |
     <a href="https://crates.io/crates/criterion">


### PR DESCRIPTION
The GitHub badge in the readme doesn't appear to be using the correct repository.