### PR TITLE
Set plot backgrounds to white for legibility on dark backgrounds

### DIFF
--- a/plot/src/lib.rs
+++ b/plot/src/lib.rs
@@ -478,6 +478,12 @@ impl Figure {
             }
         }
 
+        // fillstyle transparent solid 1 is required for noborder to take effect?
+        s.push_str(
+            "\nset object 1 rect from screen 0,0 to screen 1,1 behind \
+                fillcolor rgb\"#ffffff\" fillstyle transparent solid 1 noborder\n",
+        );
+
         // TODO This removes the crossbars from the ends of error bars, but should be configurable
         s.push_str("\nunset bars\n");
 

--- a/src/plot/plotters_backend/distributions.rs
+++ b/src/plot/plotters_backend/distributions.rs
@@ -53,7 +53,7 @@ fn abs_distribution(
     let kde_xs_sample = Sample::new(&kde_xs);
 
     let path = context.report_path(id, &format!("{}.svg", statistic));
-    let root_area = SVGBackend::new(&path, size.unwrap_or(SIZE)).into_drawing_area();
+    let root_area = new_svg_drawing_area(&path, size.unwrap_or(SIZE));
 
     let x_range = plotters::data::fitting_range(kde_xs_sample.iter());
     let mut y_range = plotters::data::fitting_range(ys.iter());
@@ -213,7 +213,7 @@ fn rel_distribution(
     };
     let y_range = plotters::data::fitting_range(ys.iter());
     let path = context.report_path(id, &format!("change/{}.svg", statistic));
-    let root_area = SVGBackend::new(&path, size.unwrap_or(SIZE)).into_drawing_area();
+    let root_area = new_svg_drawing_area(&path, size.unwrap_or(SIZE));
 
     let mut chart = ChartBuilder::on(&root_area)
         .margin((5).percent())

--- a/src/plot/plotters_backend/iteration_times.rs
+++ b/src/plot/plotters_backend/iteration_times.rs
@@ -16,7 +16,7 @@ pub(crate) fn iteration_times_figure(
     let scaled_y = Sample::new(&scaled_y);
 
     let size = size.unwrap_or(SIZE);
-    let root_area = SVGBackend::new(path, size).into_drawing_area();
+    let root_area = new_svg_drawing_area(&path, size);
 
     let mut cb = ChartBuilder::on(&root_area);
     if let Some(title) = title {
@@ -82,7 +82,7 @@ pub(crate) fn iteration_times_comparison_figure(
     let scaled_base_y = Sample::new(scaled_base_y);
 
     let size = size.unwrap_or(SIZE);
-    let root_area = SVGBackend::new(path, size).into_drawing_area();
+    let root_area = new_svg_drawing_area(&path, size);
 
     let mut cb = ChartBuilder::on(&root_area);
     if let Some(title) = title {

--- a/src/plot/plotters_backend/mod.rs
+++ b/src/plot/plotters_backend/mod.rs
@@ -1,6 +1,9 @@
+use std::path::Path;
+
 use super::{PlotContext, PlotData, Plotter};
 use crate::measurement::ValueFormatter;
 use crate::report::{BenchmarkId, ComparisonData, MeasurementData, ValueType};
+use plotters::coord::Shift;
 use plotters::data::float::pretty_print_float;
 use plotters::prelude::*;
 
@@ -32,6 +35,23 @@ fn convert_size(size: Option<(usize, usize)>) -> Option<(u32, u32)> {
 }
 #[derive(Default)]
 pub struct PlottersBackend;
+
+pub(crate) fn new_svg_drawing_area(
+    path: &Path,
+    size: (u32, u32),
+) -> DrawingArea<SVGBackend, Shift> {
+    let area = SVGBackend::new(path, size).into_drawing_area();
+    area.draw(&Rectangle::new(
+        [(0, 0), (size.0 as i32, size.1 as i32)],
+        ShapeStyle {
+            color: RGBAColor(255, 255, 255, 1.0),
+            filled: true,
+            stroke_width: 0,
+        },
+    ))
+    .unwrap();
+    area
+}
 
 #[allow(unused_variables)]
 impl Plotter for PlottersBackend {

--- a/src/plot/plotters_backend/pdf.rs
+++ b/src/plot/plotters_backend/pdf.rs
@@ -36,7 +36,7 @@ pub(crate) fn pdf_comparison_figure(
     let y_range = data::fitting_range(base_ys.iter().chain(ys.iter()));
 
     let size = size.unwrap_or(SIZE);
-    let root_area = SVGBackend::new(&path, (size.0, size.1)).into_drawing_area();
+    let root_area = new_svg_drawing_area(&path, size);
 
     let mut cb = ChartBuilder::on(&root_area);
 
@@ -130,7 +130,7 @@ pub(crate) fn pdf_small(
     let path = context.report_path(id, "pdf_small.svg");
 
     let size = size.unwrap_or(SIZE);
-    let root_area = SVGBackend::new(&path, (size.0, size.1)).into_drawing_area();
+    let root_area = new_svg_drawing_area(&path, size);
 
     let mut chart = ChartBuilder::on(&root_area)
         .margin((5).percent())
@@ -206,7 +206,7 @@ pub(crate) fn pdf(
     let xs_ = Sample::new(&xs);
 
     let size = size.unwrap_or(SIZE);
-    let root_area = SVGBackend::new(&path, (size.0, size.1)).into_drawing_area();
+    let root_area = new_svg_drawing_area(&path, size);
 
     let range = data::fitting_range(ys.iter());
 

--- a/src/plot/plotters_backend/regression.rs
+++ b/src/plot/plotters_backend/regression.rs
@@ -38,7 +38,7 @@ pub(crate) fn regression_figure(
     };
 
     let size = size.unwrap_or(SIZE);
-    let root_area = SVGBackend::new(path, size).into_drawing_area();
+    let root_area = new_svg_drawing_area(&path, size);
 
     let mut cb = ChartBuilder::on(&root_area);
     if let Some(title) = title {
@@ -167,7 +167,7 @@ pub(crate) fn regression_comparison_figure(
     let y_max = point.max(base_point);
 
     let size = size.unwrap_or(SIZE);
-    let root_area = SVGBackend::new(path, size).into_drawing_area();
+    let root_area = new_svg_drawing_area(&path, size);
 
     let mut cb = ChartBuilder::on(&root_area);
     if let Some(title) = title {

--- a/src/plot/plotters_backend/summary.rs
+++ b/src/plot/plotters_backend/summary.rs
@@ -34,8 +34,7 @@ pub fn line_comparison(
         plotters::data::fitting_range(series_data.iter().flat_map(|(_, xs, _)| xs.iter()));
     let y_range =
         plotters::data::fitting_range(series_data.iter().flat_map(|(_, _, ys)| ys.iter()));
-    let root_area = SVGBackend::new(&path, SIZE)
-        .into_drawing_area()
+    let root_area = new_svg_drawing_area(&path, SIZE)
         .titled(&format!("{}: Comparison", title), (DEFAULT_FONT, 20))
         .unwrap();
 
@@ -202,8 +201,7 @@ pub fn violin(
 
     let size = (960, 150 + (18 * all_curves.len() as u32));
 
-    let root_area = SVGBackend::new(&path, size)
-        .into_drawing_area()
+    let root_area = new_svg_drawing_area(&path, size)
         .titled(&format!("{}: Violin plot", title), (DEFAULT_FONT, 20))
         .unwrap();
 

--- a/src/plot/plotters_backend/t_test.rs
+++ b/src/plot/plotters_backend/t_test.rs
@@ -15,8 +15,7 @@ pub(crate) fn t_test(
     y_range.start = 0.0;
     y_range.end *= 1.1;
 
-    let size = size.unwrap_or(SIZE);
-    let root_area = new_svg_drawing_area(&path, size);
+    let root_area = new_svg_drawing_area(&path, size.unwrap_or(SIZE));
 
     let mut chart = ChartBuilder::on(&root_area)
         .margin((5).percent())

--- a/src/plot/plotters_backend/t_test.rs
+++ b/src/plot/plotters_backend/t_test.rs
@@ -15,7 +15,8 @@ pub(crate) fn t_test(
     y_range.start = 0.0;
     y_range.end *= 1.1;
 
-    let root_area = SVGBackend::new(&path, size.unwrap_or(SIZE)).into_drawing_area();
+    let size = size.unwrap_or(SIZE);
+    let root_area = new_svg_drawing_area(&path, size);
 
     let mut chart = ChartBuilder::on(&root_area)
         .margin((5).percent())


### PR DESCRIPTION
This PR sets plot backgrounds to white in both the gnuplot and plotters backends. I'm not sure how to test this, so for verification, attached are the reports you get when running the following command with and without gnuplot installed:

```sh
cargo test --features plotters --features html_reports --test criterion_tests test_output_files
```

[criterion-output.zip](https://github.com/user-attachments/files/22321228/criterion-output.zip)

The reports are saved to a tempdir, so if you would like to replicate this yourself, you should place the following at the top of the test function and then add `-- --nocapture` to the command above.

```rust
let mut tempdir = temp_dir();
tempdir.disable_cleanup(true);
eprintln!("{tempdir:?}");  // copy this and cd to it in another shell
```

Screenshots of the reports in dark mode:

Gnuplot:
<img width="991" height="761" alt="report" src="https://github.com/user-attachments/assets/979f2064-6668-4671-bd1b-4c24ecc4828f" />


Plotters:
<img width="1006" height="758" alt="report" src="https://github.com/user-attachments/assets/c42e8b66-7467-413e-86ca-4514aa0555c6" />

