### PR TITLE
Added `#[doc(hidden)]` to `criterion_group` to avoid raising `missing-docs` error

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -61,6 +61,7 @@
 #[macro_export]
 macro_rules! criterion_group {
     (name = $name:ident; config = $config:expr; targets = $( $target:path ),+ $(,)*) => {
+        #[doc(hidden)]
         pub fn $name() {
             let mut criterion: $crate::Criterion<_> = $config
                 .configure_from_args();


### PR DESCRIPTION
As  per title, this PR simply ensures that the `criterion_group` macro no longer raises the `missing-docs` when such constraint is setup in the main cargo of a workspace. 

This PR closes issues such as #826 