### PR TITLE
Add commandline example and filtering section to profiling docs

### DIFF
--- a/book/src/user_guide/profiling.md
+++ b/book/src/user_guide/profiling.md
@@ -4,6 +4,14 @@ When optimizing code, it's often helpful to profile it to help understand why
 it produces the measured performance characteristics. Criterion.rs has several
 features to assist with profiling benchmarks.
 
+The path to the benchmark executable used can be found in the `cargo bench` output: `  Running benches/mybenchmark.rs (/path/to/benchmark/executable)`.
+
+tl;dr: command
+```sh
+/path/to/benchmark/executable --bench --benchmark-time 5 my_group/my_function
+```
+will run the benchmark function named `my_function` in gropu `my_group` for 5 seconds.
+
 ### Note on running benchmark executables directly
 
 Because of how Cargo passes certain command-line flags (see the FAQ for more details) when running
@@ -23,6 +31,11 @@ measurements.
 For users of external profilers such as Linux perf, simply run the benchmark
 executable(s) under your favorite profiler, passing the profile-time argument.
 For users of in-process profilers such as Google's `cpuprofiler`, read on.
+
+### Filtering benchmarks
+
+Its possible to filter to specific groups or functions by passing their respective names as an
+argument to the benchmark executable. Group names being the string specified in `Criterion::benchmark_group` and function names from `BenchmarkId`, which is the first argument to `bench_function`, `bench_with_input`, etc. 
 
 ### Implementing In-Process Profiling Hooks
 


### PR DESCRIPTION
The current profiling docs lack some non-obvious information to help users get started with profiling far more easily:
- Where the benchmark executable can be found
- How to filter to specific benchmarks, to profile them individually

This PR adds some basic docs for these, and a tl;dr: example command.